### PR TITLE
Update documentation for new config in langchecker + nits

### DIFF
--- a/products/appstores/new_release_android.md
+++ b/products/appstores/new_release_android.md
@@ -64,84 +64,51 @@ $ git checkout beta48
 $ atom app/config/sources.inc.php
 ```
 
-You need to add the new file to `$appstores_lang`. In this case changing from:
+At this point you’re ready to add the new files to `$appstores_lang`. The easiest way is to start by identifying the files used for the previous cycle. For example, if you’re adding 48 Beta and promoting 47 to release, identify files for 47 Beta and 46 Release:
 ```PHP
 $appstores_lang = [
     ...
-    'fx_android/whatsnew/android_46.lang',
-    'fx_android/whatsnew/android_47_beta.lang',
+    'fx_android/whatsnew/android_46.lang' => [
+        'deadline'          => '2016-04-26',
+        'supported_locales' => array_merge($fx_android_store, ['ar']),
+    ],
+    'fx_android/whatsnew/android_47_beta.lang' => [
+        'supported_locales' => $fx_android_store,
+    ],
 ```
 
-To:
+What you’ll need to do is:
+* Add the two new files for 48 Beta (`fx_android/whatsnew/android_48_beta.lang`) and 47 release (`fx_android/whatsnew/android_47.lang`) by copying the ones used in the previous cycle and updating the version number.
+* Mark the previous beta as obsolete by adding to its definition:
+```
+'flags' => [
+    'obsolete' => ['all'],
+],
+```
+* Remove the deadline from the previous release and add it to the new one.
+
 ```PHP
 $appstores_lang = [
     ...
-    'fx_android/whatsnew/android_46.lang',
-    'fx_android/whatsnew/android_47_beta.lang',
-    'fx_android/whatsnew/android_47.lang',
-    'fx_android/whatsnew/android_48_beta.lang',
+    'fx_android/whatsnew/android_46.lang' => [
+        'supported_locales' => array_merge($fx_android_store, ['ar']),
+    ],
+    'fx_android/whatsnew/android_47_beta.lang' => [
+        'flags' => [
+            'obsolete' => ['all'],
+        ],
+        'supported_locales' => $fx_android_store,
+    ],
+    'fx_android/whatsnew/android_47.lang' => [
+        'deadline'          => '2016-06-07',
+        'supported_locales' => array_merge($fx_android_store, ['ar']),
+    ],
+    'fx_android/whatsnew/android_48_beta.lang' => [
+        'supported_locales' => $fx_android_store,
+    ],
 ```
 
-Then update `$lang_flags['appstores']` marking the the old beta file as obsolete. From:
-```PHP
-$lang_flags['appstores'] = [
-    ...
-    'fx_android/whatsnew/android_44.lang'      => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_45.lang'      => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_46_beta.lang' => [ 'obsolete' => ['all'] ],
-    ...
-```
-
-To:
-```PHP
-$lang_flags['appstores'] = [
-    ...
-    'fx_android/whatsnew/android_44.lang'      => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_45.lang'      => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_46_beta.lang' => [ 'obsolete' => ['all'] ],
-    'fx_android/whatsnew/android_47_beta.lang' => [ 'obsolete' => ['all'] ],
-    ...
-```
-
-Add a deadline for the new file, removing the old one. From:
-```PHP
-$deadline = [
-    ...
-    'fx_android/whatsnew/android_46.lang'      => '2016-04-26', // appstores project
-    ...
-];
-```
-
-To:
-```PHP
-$deadline = [
-    ...
-    'fx_android/whatsnew/android_47.lang'      => '2016-06-07', // appstores project
-    ...
-];
-```
-
-Finally add the supported locales for these new files. From:
-```PHP
-'appstores' => [
-    ...
-    'fx_android/whatsnew/android_45.lang'      => array_merge($fx_android_store, ['ar']),
-    'fx_android/whatsnew/android_46.lang'      => array_merge($fx_android_store, ['ar']),
-    'fx_android/whatsnew/android_46_beta.lang' => $fx_android_store,
-    'fx_android/whatsnew/android_47_beta.lang' => $fx_android_store,
-```
-
-To:
-```PHP
-'appstores' => [
-    ...
-    'fx_android/whatsnew/android_45.lang'      => array_merge($fx_android_store, ['ar']),
-    'fx_android/whatsnew/android_46.lang'      => array_merge($fx_android_store, ['ar']),
-    'fx_android/whatsnew/android_47.lang'      => array_merge($fx_android_store, ['ar']),
-    'fx_android/whatsnew/android_46_beta.lang' => $fx_android_store,
-    'fx_android/whatsnew/android_47_beta.lang' => $fx_android_store,
-    'fx_android/whatsnew/android_48_beta.lang' => $fx_android_store,
-```
+At this point the previous release (46) is not obsolete yet, you can mark it as such the next time you update the file. As a general rule, there should be only two non obsolete release files near the end of the cycle.
 
 Now you can commit your changes to Langchecker. Always check with `git status` to confirm that you’re only including changes to `sources.inc.php`.
 ```
@@ -236,4 +203,4 @@ Now you’re ready to open pull requests for each of the three involved reposito
 * stores_l10n: https://github.com/mozilla-l10n/stores_l10n/pull/63
 * appstores: https://github.com/mozilla-l10n/appstores/pull/70
 
-If you're using the l10n-drivers VM, both **langchecker** and **stores_l10n** are forks, so you'll find them in your user account, e.g. `https://github.com/flodolo/langchecker/`. **appstores**, on the other hand, is a direct clone of the mozilla-l10n repository.
+If you’re using the l10n-drivers VM, both **langchecker** and **stores_l10n** are forks, so you’ll find them in your user account, e.g. `https://github.com/flodolo/langchecker/`. **appstores**, on the other hand, is a direct clone of the mozilla-l10n repository.

--- a/products/appstores/new_release_ios.md
+++ b/products/appstores/new_release_ios.md
@@ -50,79 +50,40 @@ $ git checkout ios6_0
 $ atom app/config/sources.inc.php
 ```
 
-You need to add the new file to `$appstores_lang`. In this case changing from:
+At this point you’re ready to add the new file to `$appstores_lang`. The easiest way is to start by identifying the file used for the previous cycle. For example, if you’re adding Firefox for iOS 6.0, identify the file used for 5.0:
 ```PHP
 $appstores_lang = [
     ...
-    'fx_ios/whatsnew/ios_4_0.lang',
-    'fx_ios/whatsnew/ios_5_0.lang',
-];
+    'fx_ios/whatsnew/ios_5_0.lang' => [
+        'deadline'          => '2016-07-27',
+        'supported_locales' => $fx_ios_store,
+    ],
 ```
 
-To:
+What you’ll need to do is:
+* Add the new file for 6.0 (`fx_ios/whatsnew/ios_6_0.lang`) by copying the one used in the previous cycle and updating the version number.
+* Mark the previous file as obsolete by adding to its definition:
+```
+'flags' => [
+    'obsolete' => ['all'],
+],
+```
+* Remove the deadline from the previous file and add it to the new one.
+
 ```PHP
 $appstores_lang = [
     ...
-    'fx_ios/whatsnew/ios_4_0.lang',
-    'fx_ios/whatsnew/ios_5_0.lang',
-    'fx_ios/whatsnew/ios_6_0.lang',
-];
+    'fx_ios/whatsnew/ios_5_0.lang' => [
+        'flags' => [
+            'obsolete' => ['all'],
+        ],
+        'supported_locales' => $fx_ios_store,
+    ],
+    'fx_ios/whatsnew/ios_6_0.lang' => [
+        'deadline'          => '2017-12-20',
+        'supported_locales' => $fx_ios_store,
+    ],
 ```
-
-Then update `$lang_flags['appstores']` marking the the old file as obsolete. From:
-```PHP
-$lang_flags['appstores'] = [
-    ...
-    'fx_ios/whatsnew/ios_2_1.lang'         => [ 'obsolete' => ['all'] ],
-    'fx_ios/whatsnew/ios_4_0.lang'         => [ 'obsolete' => ['all'] ],
-];
-```
-
-To:
-```PHP
-$lang_flags['appstores'] = [
-    ...
-    'fx_ios/whatsnew/ios_2_1.lang'         => [ 'obsolete' => ['all'] ],
-    'fx_ios/whatsnew/ios_4_0.lang'         => [ 'obsolete' => ['all'] ],
-    'fx_ios/whatsnew/ios_5_0.lang'         => [ 'obsolete' => ['all'] ],
-];
-```
-
-Add a deadline for the new file, removing the old one. From:
-```PHP
-$deadline = [
-    ...
-    'fx_ios/whatsnew/ios_5_0.lang'        => '2016-07-27', // appstores project
-];
-```
-
-To:
-```PHP
-$deadline = [
-    ...
-    'fx_ios/whatsnew/ios_6_0.lang'        => '2016-12-20', // appstores project
-];
-```
-
-Finally add the supported locales for this new file. From:
-```PHP
-'appstores' => [
-    ...
-    'fx_ios/whatsnew/ios_4_0.lang'         => $fx_ios_store,
-    'fx_ios/whatsnew/ios_5_0.lang'         => $fx_ios_store,
-],
-```
-
-To:
-```PHP
-'appstores' => [
-    ...
-    'fx_ios/whatsnew/ios_4_0.lang'         => $fx_ios_store,
-    'fx_ios/whatsnew/ios_5_0.lang'         => $fx_ios_store,
-    'fx_ios/whatsnew/ios_6_0.lang'         => $fx_ios_store,
-],
-```
-
 Now you can commit your changes to Langchecker. Always check with `git status` to confirm that you’re only including changes to `sources.inc.php`.
 ```
 $ cd ~/mozilla/git/langchecker/
@@ -209,4 +170,4 @@ Now you’re ready to open pull requests for each of the three involved reposito
 * stores_l10n: https://github.com/mozilla-l10n/stores_l10n/pull/65
 * appstores: https://github.com/mozilla-l10n/appstores/pull/72
 
-If you're using the l10n-drivers VM, both **langchecker** and **stores_l10n** are forks, so you'll find them in your user account, e.g. `https://github.com/flodolo/langchecker/`. **appstores**, on the other hand, is a direct clone of the mozilla-l10n repository.
+If you’re using the l10n-drivers VM, both **langchecker** and **stores_l10n** are forks, so you’ll find them in your user account, e.g. `https://github.com/flodolo/langchecker/`. **appstores**, on the other hand, is a direct clone of the mozilla-l10n repository.

--- a/products/firefox_android/adding_multilocales.md
+++ b/products/firefox_android/adding_multilocales.md
@@ -1,7 +1,7 @@
 # Adding a new locale to the multi-locales build
 Android has two different types of builds: a multi-locale build that ships in Google Play Store, and a single-locale build (containing only one locale) that is mostly used for testing.
 
-The list of locales included in the multi-locales build is stored inside a file named **maemo-locales** within Mozilla’s code repositories. Since we want to create Aurora builds, the file will be in mozilla-aurora: https://hg.mozilla.org/releases/mozilla-aurora/file/default/mobile/android/locales/maemo-locales
+The list of locales included in the multi-locales build is stored inside a file named **maemo-locales** within Mozilla’s code repositories. Since the goal is to create Aurora builds, the file will be in mozilla-aurora: https://hg.mozilla.org/releases/mozilla-aurora/file/default/mobile/android/locales/maemo-locales
 
 ## File a bug to add the new locale
 You need to file a bug in Firefox for Android::General requesting the new locale (see for example [this bug for Serbian](https://bugzilla.mozilla.org/show_bug.cgi?id=1262464)). You can use this [bug template] to make things faster:

--- a/products/firefox_android/adding_singlelocale.md
+++ b/products/firefox_android/adding_singlelocale.md
@@ -1,7 +1,7 @@
 # Adding a new locale to the single-locale build
 Android has two different types of builds: a multi-locale build that ships in Google Play Store, and a single-locale build (containing only one locale) that is mostly used for testing.
 
-The list of locales for which we create single-locale builds is stored inside a file named **all-locales** within Mozilla’s code repositories. Since we want to create Aurora builds, the file will be in mozilla-aurora: https://hg.mozilla.org/releases/mozilla-aurora/file/default/mobile/android/locales/all-locales
+The list of locales for which single-locale builds are created is stored inside a file named **all-locales** within Mozilla’s code repositories. Since the goal is to create Aurora builds, the file will be in mozilla-aurora: https://hg.mozilla.org/releases/mozilla-aurora/file/default/mobile/android/locales/all-locales
 
 ## File a bug to add the new locale
 You need to file a bug in Firefox for Android::General requesting the new locale (see for example [this bug for Guaraní](https://bugzilla.mozilla.org/show_bug.cgi?id=1271839)). You can use this [bug template] to make things faster (update with the appropriate locale code and language name).

--- a/products/firefox_android/setup_searchplugins.md
+++ b/products/firefox_android/setup_searchplugins.md
@@ -90,7 +90,7 @@ $ hg status
 ? mobile/searchplugins/wikipedia-gn.xml
 ? mobile/searchplugins/yahoo-espanol.xml
 ```
-The `?` indicates that these file are not tracked by Mercurial, so we need to add them. If you’re in the root of the repository, you can add the entire `mobile` folder instead of the single files:
+The `?` indicates that these file are not tracked by Mercurial, so they need to be added. If you’re in the root of the repository, you can add the entire `mobile` folder instead of the single files:
 
 ```
 $ hg add mobile
@@ -141,7 +141,7 @@ $ cd ~/mozilla/mercurial/l10n/gn/mozilla-aurora
 $ hg import --no-commit ~/Desktop/bug123456.patch
 ```
 
-**Note:** You can drag and drop the patch file on the terminal to get its full path instead of typing it. In other words, type `hg import --no-commit `, then drag the icon of the patch on the Terminal's window, the path will appear automatically.
+**Note:** You can drag and drop the patch file on the terminal to get its full path instead of typing it. In other words, type `hg import --no-commit `, then drag the icon of the patch on the Terminal’s window, the path will appear automatically.
 
 At this point you’re ready to modify the files, and create a new patch. The only different is that you will need to use a different filename, for example `bug123456v1.patch`.
 

--- a/products/firefox_android/testing_android.md
+++ b/products/firefox_android/testing_android.md
@@ -18,16 +18,16 @@ Then, choose the .apk link out of the 3 possible options listed. Download should
 
 It is strongly suggested to start using these builds on a daily basis, so that you can get into as many screens as possible and check that everything looks fine.
 
-It is important that the people testing the localization be not only the one(s) who have localized. Ask other people from your community to help test so we have fresh eyes looking at your work.
+It is important that the people testing the localization be not only the one(s) who have localized. Ask other people from your community to help test in order to have fresh eyes looking at your work.
 
 ## Testing on multi-locale builds (shipping in Play Store)
 
-Once the Fennec Project Manager (currently **delphine** at **mozilla** dot **com**) sees that you’ve done at least one cycle on a single-locale build, that nothing breaks when we do sign-offs, that you’ve continued keeping your work up to date, and that you have been TESTING it - we will consider adding your language to the multi-locale builds. This means that - congratulations! - your locale will now officially be shipping on Firefox for Android.
+Once the Fennec Project Manager (currently **delphine** at **mozilla** dot **com**) sees that you’ve done at least one cycle on a single-locale build, that nothing breaks during sign-offs, that you’ve continued keeping your work up to date, and that you have been TESTING it - l10n-drivers will consider adding your language to the multi-locale builds. This means that - congratulations! - your locale will now officially be shipping on Firefox for Android.
 
-Once we add your locale to the multi-locale builds, it will "ride the trains" like for Firefox Desktop. It will first ship on Aurora in the Play Store, then 6 weeks later it will ship on Beta, and 6 weeks after that, it will arrive on Release.
+Once your locale is added to the multi-locale builds, it will "ride the trains" like for Firefox Desktop. It will first ship on Aurora in the Play Store, then 6 weeks later it will ship on Beta, and 6 weeks after that, it will arrive on Release.
 
-Once you start shipping in the Play Store, it makes sense to stop testing on single-locale builds. We suggest you now start testing and using the Aurora Play Store version, since this is the branch that you localize and work on. It’s good to have other members in the community use the beta and release version too though, in case anything breaks with updates.
+Once you start shipping in the Play Store, it makes sense to stop testing on single-locale builds. It’s strongly suggested you now start testing and using the Aurora Play Store version, since this is the branch that you localize and work on. It’s good to have other members in the community use the beta and release version too though, in case anything breaks with updates.
 
 When testing the multi-locale build, keep in mind and look out for the same issues and aspects called out for the single-locale builds in the section above.
 
-We send out regular reminders about merge days, android updates, schedule and important info on [dev.l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n). Please make sure you’re following this list closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.
+l10n-drivers send out regular reminders about merge days, android updates, schedule and important info on [dev.l10n mailing list](https://lists.mozilla.org/listinfo/dev-l10n). Please make sure you’re following this list closely so that you get regular updates about which part of the cycle you’re at, when you need to finish your work, and anything relevant to what you are doing.

--- a/products/firefox_desktop/setup_searchplugins.md
+++ b/products/firefox_desktop/setup_searchplugins.md
@@ -75,7 +75,7 @@ Some locales might have a more complex definition, with searchplugins changing b
 }
 ```
 
-To make sure you're not creating a broken JSON, you can test the final content with an online validator like [jsonlint](http://jsonlint.com/).
+To make sure you’re not creating a broken JSON, you can test the final content with an online validator like [jsonlint](http://jsonlint.com/).
 
 ### XML files
 Searchplugins are stored in [mozilla-central](https://hg.mozilla.org/mozilla-central/file/default/browser/locales/searchplugins) in `/browser/locales/searchplugins`.
@@ -114,7 +114,7 @@ Unlike Wikipedia, never copy the file from en-US, since Yahoo is the default and
 ## Creating a patch for review (mozilla-unified repository)
 If you plan to create a patch instead of using mozreview, you can refer to the instructions available in the second part of the document, simply working inside your local clone of mozilla-unified as repository.
 
-After you've created all the files you need, check the status of the repository
+After you’ve created all the files you need, check the status of the repository
 ```
 $ hg status
 M browser/locales/search/list.json
@@ -136,7 +136,7 @@ Let’s create a bookmark for this pending work, for example `bug1304757`.
 $ hg bookmark bug1304757
 ```
 
-Commit the changes with a commit message that includes the reviewer's nickname after `r?`, for example if flod is the reviewer:
+Commit the changes with a commit message that includes the reviewer’s nickname after `r?`, for example if flod is the reviewer:
 ```
 $ hg commit -m "Bug 1304757 - [ur] Search engine setup for Firefox for Urdu, r?flod"
 ```
@@ -241,7 +241,7 @@ More information about this workflow are available in these pages:
 http://mozilla-version-control-tools.readthedocs.io/en/latest/hgmozilla/firefoxworkflow.html
 https://www.mercurial-scm.org/wiki/Bookmarks
 
-## Setting up files for locale's repository
+## Setting up files for locale’s repository
 ### region.properties
 region.properties is stored in `/browser/chrome/browser-region` and it contains information about protocol handlers. You can use [this region.properties model](desktop_region.properties) as a base, making sure to remove non existing searchplugins from `search.order`.
 
@@ -255,7 +255,7 @@ $ cd ~/mozilla/mercurial/l10n/ur/mozilla-aurora
 $ hg status
 ? browser/chrome/browser-region/region.properties
 ```
-The `?` indicates that these file are not tracked by Mercurial, so we need to add them. If you’re in the root of the repository, you can add the entire `mobile` folder instead of the single files:
+The `?` indicates that these file are not tracked by Mercurial, so they need to be added. If you’re in the root of the repository, you can add the entire `mobile` folder instead of the single files:
 
 ```
 $ hg add browser

--- a/products/mozilla_org/import_locamotion.md
+++ b/products/mozilla_org/import_locamotion.md
@@ -1,6 +1,6 @@
 # Importing strings from Pootle
 
-Pootle doesn’t commit directly to the repository, periodically we need to import strings.
+Pootle doesn’t commit directly to the repository, periodically strings need to be imported.
 
 There are two ways to import strings:
 * Directly from the online [mozilla-lang repository].

--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -10,7 +10,7 @@ Mozilla.org is highly visible because the site houses the basic info of all Mozi
 * Locamotion: https://mozilla.locamotion.org/projects/mozilla_lang/
 * Web dashboard: https://l10n.mozilla-community.org/webdashboard/?locale={locale_code}. Visit this page on a regular basis to check localization progress, pending work, deadline, and errors that were introduced during translation
 
-We highly advise you to ask other community members to conduct peer review not only on Pontoon or Locamotion, but on staging. While not all the languages are required for certain projects, each community can opt in the projects at a later time.
+It’s highly advised you to ask other community members to conduct peer review not only on Pontoon or Locamotion, but on staging. While not all the languages are required for certain projects, each community can opt in the projects at a later time.
 
 ## What to Test
 
@@ -53,7 +53,7 @@ You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.or
 
 Updated translations are pushed to the production server almost daily.
 
-When a brand new page is available for localization, it won't be enabled in production until it's fully localized. When existing pages receive updates with new strings, this new content won't be displayed on production until localized, to avoid displaying a mix of English and localized text.
+When a brand new page is available for localization, it won’t be enabled in production until it’s fully localized. When existing pages receive updates with new strings, this new content won’t be displayed on production until localized, to avoid displaying a mix of English and localized text.
 
 In some cases pages receive major updates that require a complete rewrite of the template: if this happens, the old template is kept online only for a short period of time and, when removed, it will cause the URL to redirect users to the English version.
 
@@ -64,4 +64,4 @@ In some cases pages receive major updates that require a complete rewrite of the
 
 If you work on Pontoon, it is safe to say that it will take less than an hour to see your changes reflected on the dashboard and the dev server.
 
-When a project has a firm deadline to meet, we will communicate it through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects.
+When a project has a firm deadline to meet, it will be communicated through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects.

--- a/products/mozilla_org/updating_mozillaorg_production.md
+++ b/products/mozilla_org/updating_mozillaorg_production.md
@@ -13,7 +13,7 @@ meld path/to/trunk_repository path/to/production_repository
 If you’re using the virtual machine described in [this document](/config/setup_l10ndrivers_vm.md), there are a few shortcuts:
 * `trunkst` will move into the trunk folder, and check the status (`git status`).
 * `prodst` will do the same for production, but will also fetch updates from trunk in case you want to cherry-pick changesets (see next section).
-* `mozmeld` will open meld with trunk on the left, and production on the right. Use alt+up/down to move to the next change, use alt+right to move from trunk to production. **Don’t** move the README file, since they're different between the two repositories.
+* `mozmeld` will open meld with trunk on the left, and production on the right. Use alt+up/down to move to the next change, use alt+right to move from trunk to production. **Don’t** move the README file, since they’re different between the two repositories.
 * `gitup` will update all Git repositories, discard pending changing, and checkout master branch.
 
 ## Cherry-picking changes

--- a/products/mozilla_org/working_bedrock.md
+++ b/products/mozilla_org/working_bedrock.md
@@ -23,11 +23,11 @@ At this point Bedrock will be available at http://localhost:8000
 
 In the virtual machine the locale folder is a symbolic link to the mozilla.org trunk l10n repository.
 
-Don't forget to exit the virtual environment by running `deactivate` when you’re finished.
+Don’t forget to exit the virtual environment by running `deactivate` when you’re finished.
 
 ## Extracting strings from a template
 
-The first part is to identify the template (or templates) you need to extract strings from. For example, assuming that you want to extract strings from `bedrock/mozorg/templates/mozorg/contribute/signup.html`, you would run from Bedrock's main folder:
+The first part is to identify the template (or templates) you need to extract strings from. For example, assuming that you want to extract strings from `bedrock/mozorg/templates/mozorg/contribute/signup.html`, you would run from Bedrock’s main folder:
 ```
 $ cd ~/mozilla/git/bedrock/
 $ source venv/bin/activate
@@ -72,7 +72,7 @@ There are some [shared .lang files](https://github.com/mozilla/bedrock/blob/mast
 * main.lang
 * download_button.lang
 
-If a string is available in one of these files, it can be safely used by any of the other templates. This is useful, but we shouldn't make these files bigger than necessary.
+If a string is available in one of these files, it can be safely used by any of the other templates. This is useful, but these files should’t become bigger than necessary.
 
 ### Loading other .lang files
 The `add_lang_files` directive is used in templates to specify a different .lang file, or include strings from another .lang file. Example above: normally a template called `bedrock/mozorg/templates/mozorg/contribute/signup.html` should generate a file called `mozorg/contribute/signup.lang`, but instead it generates a .lang file called `mozorg/contribute/index`. Why? Because the template has this directive:
@@ -84,9 +84,9 @@ This is particularly important to understand .lang file activation.
 
 ### Activating a template
 A .lang file is active when it starts with the line `## ACTIVE ##`.
-We activate a file when all strings inside this file are translated, and the page can be displayed in production. Example: https://www.mozilla.org/firefox/new uses `firefox/new.lang` for strings:
-* https://www.mozilla.org/en-US/firefox/new will always work, since it's en-US.
-* https://www.mozilla.org/fr/firefox/new will work if `fr/firefox/new.lang` is activated. If it's not, it will redirect to en-US (or any other active locale before en-US in the accept_languages header).
+A file is activated by l10n-drivers when all strings inside this file are translated, and the page can be displayed in production. Example: https://www.mozilla.org/firefox/new uses `firefox/new.lang` for strings:
+* https://www.mozilla.org/en-US/firefox/new will always work, since it’s en-US.
+* https://www.mozilla.org/fr/firefox/new will work if `fr/firefox/new.lang` is activated. If it’s not, it will redirect to en-US (or any other active locale before en-US in the accept_languages header).
 * https://www-dev.allizom.org/fr/firefox/new will always work, because files are always active on the dev server.
 
 If you’re running Bedrock locally, you need to change `bedrock/settings/local.py` to modify the behaviour:
@@ -95,7 +95,7 @@ If you’re running Bedrock locally, you need to change `bedrock/settings/local.
 
 One important fact to keep in mind: if you add a new .lang file with the `add_lang_files` directive, the activation status will be inherited. Always double check with the production settings.
 
-It's possible to activate l10n files by using the [mark_active script](https://github.com/mozilla-l10n/langchecker/wiki/CLI-scripts-syntax#mark_active) available in Langchecker. It will activate only locales that are completely localized and don’t have any errors.
+It’s possible to activate l10n files by using the [mark_active script](https://github.com/mozilla-l10n/langchecker/wiki/CLI-scripts-syntax#mark_active) available in Langchecker. It will activate only locales that are completely localized and don’t have any errors.
 
 ### L10n tags
 Bedrock supports l10n tags through the `l10n_has_tag` function. For example:
@@ -111,7 +111,7 @@ l10n tags allow to add a new string in the template and to push it to production
 
 The tag appears as `sync_device_note` in the code, but it will appear as `## sync_device_note ##` at the beginning of the .lang file. Using underscores is preferable to dashes for tag names.
 
-It's possible to add tags to l10n files by using the [add tags script](https://github.com/mozilla-l10n/langchecker/wiki/CLI-scripts-syntax#add_tags) available in Langchecker. It will add tags only if the file translated all strings associated to it.
+It’s possible to add tags to l10n files by using the [add tags script](https://github.com/mozilla-l10n/langchecker/wiki/CLI-scripts-syntax#add_tags) available in Langchecker. It will add tags only if the file translated all strings associated to it.
 
 All tags are enabled by default on a DEV server.
 
@@ -133,7 +133,7 @@ $ source venv/bin/activate
 Remember that Bedrock on the VM-l10n uses a link to the actual trunk repository, so make sure to delete any test you make. The `templates` folder will be automatically ignored.
 
 ### Identifying l10n issues in a patch
-The most common issue is that strings are not *wrapped*, so they're not exposed by the extraction process or translated, even if the string is available in the .lang file. To identify them you need to run the patch locally with a modified .lang file, for example adding asterisks or other characters to the English string. There might be need for a tool to automatically create such a file.
+The most common issue is that strings are not *wrapped*, so they’re not exposed by the extraction process or translated, even if the string is available in the .lang file. To identify them you need to run the patch locally with a modified .lang file, for example adding asterisks or other characters to the English string. There might be need for a tool to automatically create such a file.
 
 How to read a patch and identify the string? One possible approach is to load the patch (add .patch to the PR URL) in a text editor, and use this regular expression to search for new/changed lines with wrapped strings: `^\+.*_\(.*\)`. The regular expression can be read as: search for a line starting with `+ and including a `_(…)` structure. Note that a change might be generated by a change in padding, so the block moves but the string is always the same.
 

--- a/tools/pontoon/adding_new_locale.md
+++ b/tools/pontoon/adding_new_locale.md
@@ -1,7 +1,7 @@
 # Adding a new locale on Pontoon
 
 ## Verify if the locale is already available
-Access Django's admin interface at `https://pontoon.mozilla.org/a/` (note that this is not the usual admin interface), then click `Locales`. In the next page search for the locale you want to add (safer to search for the locale code).
+Access Django’s admin interface at `https://pontoon.mozilla.org/a/` (note that this is not the usual admin interface), then click `Locales`. In the next page search for the locale you want to add (safer to search for the locale code).
 
 ## Add the new locale
 If the locale you need is not available, click the **ADD LOCALE+** button in the top right corner. For this example, let’s consider that the task is to add Amharic (am).
@@ -9,13 +9,13 @@ If the locale you need is not available, click the **ADD LOCALE+** button in the
 You will need to complete the following fields in the next page.
 
 ### Code
-It's the locale code, in this case `am`.
+It’s the locale code, in this case `am`.
 
 ### Name
-It's the language name, in this case `Amharic`.
+It’s the language name, in this case `Amharic`.
 
 ### Plural rule
-It's the GetText plural rule. This [document](http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html) has plural rules for several languages. For example, for Amharic it would be:
+It’s the GetText plural rule. This [document](http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html) has plural rules for several languages. For example, for Amharic it would be:
 ```
 nplurals=2; plural=(n > 1);
 ```
@@ -51,6 +51,6 @@ Writing direction of the script. Set to `right-to-left` if `rtl` value for the l
 ### Population
 Number of native speakers. Find locale code in [CLDR territoryInfo.json](https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/territoryInfo.json) and multiply its `_populationPercent` with the territory `_population`. Repeat if multiple occurrences of locale code exist and sum products.
 
-At this point click **SAVE** in the bottom right corner to save the new locale, and check if the locale's page is available, in this case at https://pontoon.mozilla.org/am/
+At this point click **SAVE** in the bottom right corner to save the new locale, and check if the locale’s page is available, in this case at https://pontoon.mozilla.org/am/
 
 You should also add the Pontoon Intro project to this locale, through the [standard admin interface](https://pontoon.mozilla.org/admin/projects/pontoon-intro/).

--- a/tools/webdashboards/README.md
+++ b/tools/webdashboards/README.md
@@ -9,9 +9,9 @@ There are four interdependent elements in the current webdashboard system.
 Webdashboard in itself doesn’t generate any data, it just displays information provided by Langchecker and Webstatus in JSON format.
 
 ### Langchecker
-[Langchecker](langchecker.md) is used to analyze all projects using .lang files as data sources. It also stores all configuration information needed to manage these repositories: which projects we support, which files are in each project, which locales are supported for each project or file, metadata like critical status or deadlines.
+[Langchecker](langchecker.md) is used to analyze all projects using .lang files as data sources. It also stores all configuration information needed to manage these repositories: which projects are supported, which files are in each project, which locales are supported for each project or file, metadata like critical status or deadlines.
 
-Langchecker's scripts are used to propagate changes to all .lang files, or add news ones, in l10n repositories. It also provides an API to retrieve translations, and information about coverage, i.e how many locales translated a specific string or a page, and what percentage of the l10n population that represents.
+Langchecker’s scripts are used to propagate changes to all .lang files, or add news ones, in l10n repositories. It also provides an API to retrieve translations, and information about coverage, i.e how many locales translated a specific string or a page, and what percentage of the l10n population that represents.
 
 ### Webstatus
 [Webstatus] is used to analyze external projects, currently supporting the following formats: `.po` (Gettext), `.properties`, `.xliff`, and `.ftl` (l20n). It also provides an [API](https://github.com/mozilla-l10n/webstatus/#available-urls) to get list of locales (supported, complete), in JSON or TXT format, for a specific product.

--- a/tools/webdashboards/add_locales.md
+++ b/tools/webdashboards/add_locales.md
@@ -1,13 +1,9 @@
 # Add locales to an existing file
 
-Example task: add `zh-TW` to the list of supported locales for `firefox/os/index.lang`.
+Example task: add `sv-SE` to the list of supported locales for `foundation/index.lang`.
 
 ## Updating Langchecker sources
-First you need to search for the file that you want to update in [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php). The file will appear in several portions of the configuration file:
-* The array with the list of supported .lang files: in this case the array is `$mozillaorg_lang` since the website is `www.mozilla.org`. No need to update this list, since the file is already part of this website.
-* The list of flags (optional).
-* Deadlines (optional).
-* The list of supported locale in `$langfiles_subsets['www.mozilla.org']`. That’s the part you need to update.
+First you need to search for the file that you want to update in [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php).
 
 Always remember to **work on a fork** of the main repository, and **create a branch** in your local clone. Assuming the langchecker installation is in `~/mozilla/git/langchecker`, and that the branch name you want to create is `TESTBRANCH`, the commands to use would be:
 ```
@@ -19,36 +15,42 @@ $ git checkout TESTBRANCH
 At this point you’re ready to update the configuration file.
 
 ```PHP
-'firefox/os/index.lang'                  =>
-    [
-        'cs', 'de', 'en-GB', 'fr', 'it', 'pt-BR', 'ru',
-        'uk',
+'foundation/index.lang' => [
+    'flags' => [
+        'opt-in' => ['all'],
     ],
+    'supported_locales' => [
+        'de', 'es-ES', 'fr', 'kab', 'pl', 'pt-BR', 'zh-TW',
+    ],
+],
 ```
 
-Adding `zh-TW` would result in:
+Adding `sv-SE` would result in:
 ```PHP
-'firefox/os/index.lang'                  =>
-    [
-        'cs', 'de', 'en-GB', 'fr', 'it', 'pt-BR', 'ru',
-        'uk', 'zh-TW',
+'foundation/index.lang' => [
+    'flags' => [
+        'opt-in' => ['all'],
     ],
+    'supported_locales' => [
+        'de', 'es-ES', 'fr', 'kab', 'pl', 'pt-BR', 'sv-SE', 'zh-TW',
+    ],
+],
 ```
 
 Commit the changes and open a pull request on the [main repository](https://github.com/mozilla-l10n/langchecker).
 ```
 $ cd ~/mozilla/git/langchecker
 $ git add app/config/sources.inc.php
-$ git commit -m "Add zh-TW to firefox/os/index.lang"
+$ git commit -m "Add sv-SE to foundation/index.lang"
 $ git push origin TESTBRANCH
 ```
 
 ## Adding the file to the repository
 At this point you need to run `lang_update` to actually add the file to the repository.
 ```
-lang_update all 0 zh-TW
+lang_update all 0 sv-SE
 ```
-This line updates **all** files, for website 0 (mozilla.org), for **zh-TW**.
+This line updates **all** files, for website 0 (mozilla.org), for **sv-SE**.
 
 Move in the l10n repository, make sure to add the file and commit.
 ```
@@ -58,11 +60,11 @@ Your branch is up-to-date with 'origin/master'.
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
-	zh-TW/firefox/os/index.lang
+	sv-SE/foundation/index.lang
 
 nothing added to commit but untracked files present (use "git add" to track)
 
-$ git add zh-TW
-$ git commit -m "Add firefox/ox/index.lang to zh-TW"
+$ git add sv-SE
+$ git commit -m "Add foundation/index.lang to sv-SE"
 $ git push
 ```

--- a/tools/webdashboards/add_new_file.md
+++ b/tools/webdashboards/add_new_file.md
@@ -57,7 +57,7 @@ For the list of locales you should check the definition for existing similar fil
 ```
 
 ### Priority
-Priority is optional and can defined for each file. If the priority is the same for all locales, you can assign the integer value (from 1 to 3) to a `priority` key.
+Priority is optional and can defined for each file. If the priority is the same for all locales, you can assign the integer value (from 1 to 5) to a `priority` key.
 
 ```PHP
 'mozorg/contribute/index.lang' => [
@@ -116,7 +116,7 @@ In this case, the request is to flag the file as opt-in for all locales.
 ### Deadline
 If a file is critical, you also want to set a deadline for it: in the last week before deadline the date will be displayed in orange on the Webdashboard, after deadline it will be displayed in red.
 
-If the deadline is the same for all locales, you can assign the date (as a string in ISO format dd-mm-yyyy) to a `deadline` key. In this case, deadline needs to be set to May 30th, 2016 (2016-05-30):
+If the deadline is the same for all locales, you can assign the date (as a string in ISO format YYYY-MM-DD) to a `deadline` key. In this case, deadline needs to be set to May 30th, 2016 (2016-05-30):
 
 ```PHP
 'mozorg/contribute/signup.lang' => [
@@ -131,7 +131,7 @@ If the deadline is the same for all locales, you can assign the date (as a strin
 ],
 ```
 
-It’s also possible to define different deadlines for locales using an associative array, where to each deadline (date in ISO format dd-mm-yyyy) is associated an array of locales. `all` is a special locale to represent all supported locales for this file. For example, a deadline for German and French, and a later date for other languages:
+It’s also possible to define different deadlines for locales using an associative array, where to each deadline (date in ISO format YYYY-MM-DD) is associated an array of locales. `all` is a special locale to represent all supported locales for this file. For example, a deadline for German and French, and a later date for other languages:
 
 ```PHP
 'deadline' => [

--- a/tools/webdashboards/add_new_file.md
+++ b/tools/webdashboards/add_new_file.md
@@ -34,10 +34,8 @@ Search for the definition of `$mozillaorg_lang` in `app/config/sources.inc.php` 
 ```PHP
 $mozillaorg_lang = [
     'download_button.lang' => [
-        'deadline'            => '2016-04-29',
-        'priorities'          => [
-            1 => ['all'],
-        ],
+        'deadline'          => '2016-04-29',
+        'priority '         => 1,
         'supported_locales' => $mozillaorg,
     ],
 ```
@@ -50,9 +48,7 @@ For the list of locales you should check the definition for existing similar fil
     'flags' => [
         'opt-in' => ['all'],
     ],
-    'priorities'          => [
-        2 => ['all'],
-    ],
+    'priority'          => 2,
     'supported_locales' => $getinvolved_locales,
 ],
 'mozorg/contribute/signup.lang' => [
@@ -61,21 +57,17 @@ For the list of locales you should check the definition for existing similar fil
 ```
 
 ### Priority
-Priorities are defined for each file as an array associated to the key `priorities`.
+Priority is optional and can defined for each file. If the priority is the same for all locales, you can assign the integer value (from 1 to 3) to a `priority` key.
+
 ```PHP
 'mozorg/contribute/index.lang' => [
-    'priorities'          => [
-        2 => ['all'],
-    ],
+    'priority'          => 2,
     'supported_locales' => $getinvolved_locales,
 ],
 ```
 
-If you don’t specify a priority, the file will fall back to the default priority specified for the project (in `$sites`). In this case the request is to set the file with priority 1, while the default for mozilla.org is 3.
+It’s also possible to define a more complex set of priorities using an associative array, where to each priority (a numeric key) is associated an array of locales. `all` is a special locale to represent all supported locales for this file. For example:
 
-To each priority (a numeric key) is associated an array of locales. `all` is a special locale to represent all supported locales for this file.
-
-In the example above priority 2 is assigned to all locales. You could have more complex conditions, like:
 ```PHP
 'priorities'          => [
     1 => ['de', 'fr'],
@@ -83,15 +75,18 @@ In the example above priority 2 is assigned to all locales. You could have more 
 ],
 ```
 
+If you don’t specify a priority, the file will fall back to the default priority specified for the project (in `$sites`). In this case the request is to set the file with priority 1 for French and German, while the default for mozilla.org is 3.
+
 In this case, the request is to assign priority 1 only to French and German
 ```PHP
 'mozorg/contribute/signup.lang' => [
-    'priorities'          => [
+    'priority'          => [
         1 => ['de', 'fr'],
     ],
     'supported_locales' => $getinvolved_locales,
 ],
 ```
+
 ### Flags
 Flag are defined for each file as an array associated to the key `flags`:
 ```PHP
@@ -111,7 +106,7 @@ In this case, the request is to flag the file as opt-in for all locales.
     'flags'    => [
         'opt-in' => ['all'],
     ],
-    'priorities'          => [
+    'priority'          => [
         1 => ['de', 'fr'],
     ],
     'supported_locales' => $getinvolved_locales,
@@ -121,18 +116,36 @@ In this case, the request is to flag the file as opt-in for all locales.
 ### Deadline
 If a file is critical, you also want to set a deadline for it: in the last week before deadline the date will be displayed in orange on the Webdashboard, after deadline it will be displayed in red.
 
-Flags are defined as part of the file. In this case, deadline needs to be set to May 30th, 2016 (2016-05-30 in ISO format):
+If the deadline is the same for all locales, you can assign the date (as a string in ISO format dd-mm-yyyy) to a `deadline` key. In this case, deadline needs to be set to May 30th, 2016 (2016-05-30):
+
 ```PHP
 'mozorg/contribute/signup.lang' => [
     'deadline' => '2016-05-30',
     'flags'    => [
         'opt-in' => ['all'],
     ],
-    'priorities'          => [
+    'priority'          => [
         1 => ['de', 'fr'],
     ],
     'supported_locales' => $getinvolved_locales,
 ],
+```
+
+It’s also possible to define different deadlines for locales using an associative array, where to each deadline (date in ISO format dd-mm-yyyy) is associated an array of locales. `all` is a special locale to represent all supported locales for this file. For example, a deadline for German and French, and a later date for other languages:
+
+```PHP
+'deadline' => [
+    '2016-05-30' => ['de', 'fr'],
+    '2016-06-15' => ['all'],
+];
+```
+
+Or a deadline only for French:
+
+```PHP
+'deadline' => [
+    '2016-05-30' => ['fr'],
+];
 ```
 
 ## Add the files to all locales in the l10n repository

--- a/tools/webdashboards/add_new_file.md
+++ b/tools/webdashboards/add_new_file.md
@@ -1,16 +1,19 @@
 # Add a new file to an existing project
 
 This task can be split into smaller tasks:
-* Add the file to the list of supported files (mandatory).
-* Set the flags for this file (optional).
-* Set the deadline for this file (optional).
-* Specify the list of locales supported by this file (mandatory in most occasions).
+* Add the file to the list of supported files specifying:
+    * List of supported locales.
+    * Priority (optional).
+    * Flags (optional).
+    * Deadline (optional).
 * Add the files to all locales in the l10n repository.
 
-To analyze all steps, let’s consider a practical example: you need to add a file called `mozorg/contribute/signup.lang` to the project `www.mozilla.org`. The file is `critical` only for French and German, `opt-in` for other locales, and deadline is May 30th, 2016. Most of the time a file will be critical for all locales, or won’t have any flags.
+To analyze all steps, let’s consider a practical example: you need to add a file called `mozorg/contribute/signup.lang` to the project `www.mozilla.org`. The file is priority 1 only for French and German, `opt-in` for other locales, and deadline is May 30th, 2016. Note that most of the time a file will have the same priority for all locales, and won’t have any flags.
 
 ## Add the file to the list of supported files
-The file you need to update is [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php). There is a global array `$sites` that defines all parameters of each project. For `www.mozilla.org` it looks like this:
+The file you need to update is [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php).
+
+In [app/config/websites.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/websites.inc.php) there is a global array `$sites` that defines all parameters for each project. For `www.mozilla.org` it looks like this:
 ```PHP
 0 => [
     'www.mozilla.org',
@@ -20,131 +23,116 @@ The file you need to update is [app/config/sources.inc.php](https://github.com/m
     $mozillaorg_lang,
     'en-US', // source locale
     $repositories['www.mozilla.org']['public_path'],
-    $lang_flags['www.mozilla.org'],
+    3,
     'lang',
 ],
 ```
 The array storing all supported files is the 5th element (`$mozillaorg_lang`). With time you won’t need to check the configuration array, it will be enough to search for a similar file in the same project.
 
-Search for the definition of `$mozillaorg_lang` and add the new file, remembering that files are usually in alphabetical order (snippets are an exception). This is how the definition’s begin looks:
+### Supported locales
+Search for the definition of `$mozillaorg_lang` in `app/config/sources.inc.php` and add the new file, respecting the existing alphabetical order (snippets represent an exception to this rule). This is how the definition’s begin looks:
 ```PHP
 $mozillaorg_lang = [
-    'download.lang',
-    'download_button.lang',
-    'esr.lang',
-    'firefox/accounts.lang',
-    'firefox/android/index.lang',
-    ...
-```
-
-Add your new file `mozorg/contribute/signup.lang`:
-```PHP
-$mozillaorg_lang = [
-    ...
-    'mozorg/contribute/friends.lang',
-    'mozorg/contribute/index.lang',
-    'mozorg/contribute/signup.lang',
-    'mozorg/contribute/stories.lang',
-    'mozorg/home/index.lang',    
-    ...
-```
-
-Now Langchecker knows that this file is supported by `www.mozilla.org`.
-
-## Set the flags for this file
-This is an optional step: if a file doesn’t have any flag associated, it will be considered *non critical* for all locales.
-
-Flags are defined in a global array called `$lang_flags`, where a key for each project stores all flag for each file. Usually the definition of flags immedtiately follows the array with the list of supported files. In this case:
-```PHP
-$lang_flags['www.mozilla.org'] = [
-    'download.lang'                           => [ 'critical' => ['all'] ],
-    'download_button.lang'                    => [ 'critical' => ['all'] ],
-    'firefox/accounts.lang'                   => [ 'critical' => ['all'] ],
-    'firefox/android/index.lang'              => [
-        'critical' => [$android_locales],
-        'opt-in'   => ['all'],
+    'download_button.lang' => [
+        'deadline'            => '2016-04-29',
+        'priorities'          => [
+            1 => ['all'],
+        ],
+        'supported_locales' => $mozillaorg,
     ],
-    ...
 ```
 
-You need to set this file as `critical` only for French and German, `opt-in` for other locales. Again, files are usually in alphabetical order:
+Supported locales are defined in each file as an array associated to the key `supported_locales`. If this key is missing, file will fall back to the list of locales supported for the website (project) it belongs to. For clarity it’s highly suggested to always specify the list of supported locales.
+
+For the list of locales you should check the definition for existing similar files. In this case, you can use the same settings as another `contribute` pages:
 ```PHP
-$lang_flags['www.mozilla.org'] = [
-    'download.lang'                           => [ 'critical' => ['all'] ],
-    'download_button.lang'                    => [ 'critical' => ['all'] ],
-    ...
-    'mozorg/contribute/friends.lang'          => [ 'obsolete' => ['all'] ],
-    'mozorg/contribute/index.lang'            => [
-        'critical' => ['all'],
+'mozorg/contribute/index.lang' => [
+    'flags' => [
+        'opt-in' => ['all'],
     ],
-    'mozorg/contribute/stories.lang'          => [
-        'critical' => ['all'],
-    ],    
-    ...
-```
-
-What you need to add is this definition:
-```PHP
-'mozorg/contribute/signup.lang'          => [
-    'critical' => ['de', 'fr'],
-    'opt-in'   => ['all'],
+    'priorities'          => [
+        2 => ['all'],
+    ],
+    'supported_locales' => $getinvolved_locales,
+],
+'mozorg/contribute/signup.lang' => [
+    'supported_locales' => $getinvolved_locales,
 ],
 ```
-You create a new array element using the filename as key, its value is another array. To each flag (key) is associated an array of locales. `all` is a special locale to represent all supported locales for this file.
 
-## Set the deadline for this file
+### Priority
+Priorities are defined for each file as an array associated to the key `priorities`.
+```PHP
+'mozorg/contribute/index.lang' => [
+    'priorities'          => [
+        2 => ['all'],
+    ],
+    'supported_locales' => $getinvolved_locales,
+],
+```
+
+If you don’t specify a priority, the file will fall back to the default priority specified for the project (in `$sites`). In this case the request is to set the file with priority 1, while the default for mozilla.org is 3.
+
+To each priority (a numeric key) is associated an array of locales. `all` is a special locale to represent all supported locales for this file.
+
+In the example above priority 2 is assigned to all locales. You could have more complex conditions, like:
+```PHP
+'priorities'          => [
+    1 => ['de', 'fr'],
+    2 => ['all'],
+],
+```
+
+In this case, the request is to assign priority 1 only to French and German
+```PHP
+'mozorg/contribute/signup.lang' => [
+    'priorities'          => [
+        1 => ['de', 'fr'],
+    ],
+    'supported_locales' => $getinvolved_locales,
+],
+```
+### Flags
+Flag are defined for each file as an array associated to the key `flags`:
+```PHP
+'mozorg/contribute/index.lang' => [
+    'flags' => [
+        'opt-in' => ['all'],
+    ],
+    'supported_locales' => $getinvolved_locales,
+],
+```
+
+To each flag (key) is associated an array of locales. `all` is a special locale to represent all supported locales for this file. Flags currently in use are: obsolete, opt-in.
+
+In this case, the request is to flag the file as opt-in for all locales.
+```PHP
+'mozorg/contribute/signup.lang' => [
+    'flags'    => [
+        'opt-in' => ['all'],
+    ],
+    'priorities'          => [
+        1 => ['de', 'fr'],
+    ],
+    'supported_locales' => $getinvolved_locales,
+],
+```
+
+### Deadline
 If a file is critical, you also want to set a deadline for it: in the last week before deadline the date will be displayed in orange on the Webdashboard, after deadline it will be displayed in red.
 
-Deadlines are stored in a flat array called `$deadlines`:
+Flags are defined as part of the file. In this case, deadline needs to be set to May 30th, 2016 (2016-05-30 in ISO format):
 ```PHP
-$deadline = [
-    'ads/ios_android_apr2016.lang'           => '2016-04-22',
-    'android_release.lang'                   => '2016-04-30', // appstores project
-    'apple_description_release.lang'         => '2016-03-30', // appstores project
-    'apple_screenshots_v3.lang'              => '2016-03-25', // appstores project
-    'description_beta_page.lang'             => '2015-09-30', // appstores project
-    'download_button.lang'                   => '2016-04-29',
-    ...
-```
-
-Simply add the new file and its deadline, maintaining the alphabetical order.
-```PHP
-$deadline = [
-    ...
-    'mozorg/about.lang'                      => '2015-03-26',
-    'mozorg/contribute/index.lang'           => '2015-08-10',
-    'mozorg/contribute/signup.lang'          => '2016-05-30',
-    'mozorg/contribute/stories.lang'         => '2015-08-10',
-    'mozorg/home/index.lang'                 => '2016-03-15',
-    ...
-```
-
-## Specify the list of locales supported by this file
-If you don’t specify a list of supported locales for a file, it will fallback to the list of locales supported for the website (project) it belongs to. Even in that case it’s clearer to always specify the list of locales.
-
-Language subsets are defined in a global array called `$langfiles_subsets`, where a key for each project stores all locales for each file. For `www.mozilla.org` the definition starts as:
-
-```PHP
-$langfiles_subsets = [
-    'www.mozilla.org' =>
-    [
-        'download.lang'                         => $mozillaorg,
-        'download_button.lang'                  => $mozillaorg,
-        'esr.lang'                              => ['de', 'fr'],
-```
-
-For the list of locales you should check other similar files, for example:
-```PHP
-$langfiles_subsets = [
-    'www.mozilla.org' =>
-    [
-        ...
-        'mozorg/contribute.lang'                => $getinvolved_locales,
-        'mozorg/contribute/friends.lang'        => ['cs', 'de', 'es-ES', 'fr', 'pt-BR'],
-        'mozorg/contribute/index.lang'          => $getinvolved_locales,
-        'mozorg/contribute/signup.lang'         => $getinvolved_locales,
-        'mozorg/contribute/stories.lang'        => $getinvolved_locales,
-        ...
+'mozorg/contribute/signup.lang' => [
+    'deadline' => '2016-05-30',
+    'flags'    => [
+        'opt-in' => ['all'],
+    ],
+    'priorities'          => [
+        1 => ['de', 'fr'],
+    ],
+    'supported_locales' => $getinvolved_locales,
+],
 ```
 
 ## Add the files to all locales in the l10n repository

--- a/tools/webdashboards/import_translations.md
+++ b/tools/webdashboards/import_translations.md
@@ -2,7 +2,7 @@
 
 Sometimes it’s useful to import strings from existing files. A typical example is when an existing page is replaced by a new template, with some strings in common.
 
-First of all, always make sure that your repositories are up to date. If you're using the l10n-drivers VM, simply run `gitup`.
+First of all, always make sure that your repositories are up to date. If you’re using the l10n-drivers VM, simply run `gitup`.
 
 Let’s consider a simple example: the string `Internet Health` is currently available in `main.lang`. A new page is created (`mozorg/internet-health.lang`), and it includes that string in the template. Since `main.lang` is a shared file it would be possible to avoid adding the string to the new template, but in this case you want to make sure that localizers can use an alternative translation.
 
@@ -33,7 +33,7 @@ Note that `$import_files` is an array, which means you could have more source fi
 ```PHP
 $import_files = ['main.lang', 'mozorg/home/index.lang'];
 ```
-The order is relevant: files are checked in the order they're available in the array, the first matching translation is kept.
+The order is relevant: files are checked in the order they’re available in the array, the first matching translation is kept.
 
 **Important**: make sure to not commit this change to langchecker. You can either ignore it and it will be removed the next time you run `gitup`, or reset the repository with `git reset --hard`.
 ```

--- a/tools/webdashboards/langchecker.md
+++ b/tools/webdashboards/langchecker.md
@@ -1,7 +1,9 @@
 # Langchecker
-Langchecker is the main repository to update when adding or updating files. There are two different configuration files:
+Langchecker is the main repository to update when adding or updating files. There are four different configuration files:
 * [app/config/locales.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/locales.inc.php): it contains several lists of locales, like locales supported in mozilla.org, locales only working in Fennec, etc. These lists are then used in the main configuration file to determine which locales are supported for each file. Normally you would need to update this file only when bootstrapping new languages.
-* [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php): it contains the main configuration of Langchecker.
+* [app/config/store_locales.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/store_locales.inc.php): this file is generated automatically from external data and tracks locales supported in online stores (Play Store, App Store).
+* [app/config/websites.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/websites.inc.php): it contains the configuration for websites (projects) supported in Langchecker.
+* [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php): it contains the configuration for all files supported in Langchecker.
 
 Langchecker also includes several command line scripts to manage day-to-day operations on supported repositories. For example:
 * [app/scripts/lang_update](https://github.com/mozilla-l10n/langchecker/blob/master/app/scripts/lang_update): reads the original en-US file, adds missing strings to requested files, reformat localized .lang files. It can also be used to import existing translations from another .lang file.
@@ -31,7 +33,7 @@ Let’s consider a simple website like about:healthreport. This is how its defin
     $firefoxhealthreport_lang,
     'en-US', // source locale
     $repositories['about:healthreport']['public_path'],
-    $lang_flags['about:healthreport'],
+    2,
     'lang',
 ],
 ```
@@ -42,28 +44,28 @@ The structure of each item is:
 2. Path to local repository.
 3. Folder containing locale files.
 4. Array of supported locale.
-5. Array of supported files.
+5. Array of supported files with all associated data.
 6. Reference locale code.
 7. URL to public repo (used to create links to files).
-8. Array of flags.
+8. Default priority, used as fallback when files don't specify one.
 9. Type of files (`lang`, `raw`).
 
-For each website there is a list of supported locales, but each file might only use a subset of this list. These subsets are defined in a global array called `$langfiles_subsets`.
+For each website there is a list of supported locales, but each file might only use a subset of this list.
 
-For about:healthreport, the list of supported files is stored in `$firefoxhealthreport_lang`. Flags are stored in a global array called `$lang_flags`, with a subset for each website.
+For about:healthreport, the list of supported files is stored in `$firefoxhealthreport_lang`.
 
 ```PHP
-$firefoxhealthreport_lang = ['fhr.lang'];
-$lang_flags['about:healthreport'] = [
-    'fhr.lang' => [ 'critical' => ['all'] ],
+$firefoxhealthreport_lang = [
+    'fhr.lang' => [
+        'supported_locales' => array_diff($firefox_desktop_android, $mozorg_locales),
+    ],
 ];
 ```
 
-In this case there is only one file supported (`fhr.lang`), and only one flag is associated to this file.
+In this case there is only one file supported (`fhr.lang`).
 
 Flags commonly used are:
-* **critical**: the file will be displayed in webdashboard as critical.
 * **obsolete**: the file won’t be displayed in webdashboard at all, and its strings won’t be counted in stats. It’s usually used to mark a file that will be completely deleted later but needs to remain in the repository.
 * **opt-in**: the file was requested only for some locales, but others can decide to *opt-in* and request the page for translation through Bugzilla.
 
-One last important array to keep in mind is `$deadline`. It’s not per website, it’s a flat array that stores deadlines for each file that needs one.
+For more details on the structure of this file, check the [add_new_file.md](documentation to track new files).

--- a/tools/webdashboards/update_existing_file.md
+++ b/tools/webdashboards/update_existing_file.md
@@ -17,7 +17,7 @@ Also double check the [Errors View](https://l10n.mozilla-community.org/langcheck
 ## Update the deadline
 If the file has a deadline set, you normally need to update it (e.g. plus 2 weeks from the the update).
 
-Deadlines are stored in a flat array called `$deadlines` inside [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php), simply update the date associated to this file respecting the format `YEAR-MM-DD`.
+Search for the filename in [app/config/sources.inc.php](https://github.com/mozilla-l10n/langchecker/blob/master/app/config/sources.inc.php) and simply update the date associated to this file respecting the format `YEAR-MM-DD`.
 
 ## Update the file for all locales
 At this point you need to run `lang_update` to propagate the update to all locales. Assuming that the file is called `mozorg/contribute/signup.lang`, run:


### PR DESCRIPTION
Use "you" or "passive" form, not "we".
Use apostrophe instead of straight single quote.

This is currently blocked by https://github.com/mozilla-l10n/langchecker/pull/597 but it might help with reviews.