### PR TITLE
Add test instruction for dynamic page

### DIFF
--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -66,6 +66,7 @@ If you work on Pontoon, it is safe to say that it will take less than an hour to
 
 When a project has a firm deadline to meet, it will be communicated through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects.
 
+
 ## Testing Dynamic Pages
 This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change overtime to reflect product design updates. Linguistic testing is the main focus. The instrutions below are detailed steps to get to the localized content so it can be reviewed in context.
 


### PR DESCRIPTION
- Steps need to be reviewed and verified
- See my note, one doesn't work on production but works in staging
- Need instrution for Syn if there are steps beyond the static pages and still are part of mozilla.org content.
- Any other pages missing? I did not check opt-in pages.  