### PR TITLE
Add test instruction to dynamic pages

### DIFF
--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -2,7 +2,7 @@
 
 Mozilla.org is highly visible because the site houses the basic info of all Mozilla products, conveys Mozilla’s mission, vision, and values it stands for. Additionally, it promotes initiatives and campaigns in time of these events. The localized versions reach 60% of the Mozilla users globally. It is very important that, not only the main pages are localized, they are thoroughly tested before they are launched on production.
 
-## Key Links
+## Key links
 * Production: https://www.mozilla.org/{locale_code}/
 * Staging: https://www-dev.allizom.org/{locale_code}/
 * Repository: https://github.com/mozilla-l10n/www.mozilla.org/
@@ -12,15 +12,15 @@ Mozilla.org is highly visible because the site houses the basic info of all Mozi
 
 It’s highly advised you to ask other community members to conduct peer review not only on Pontoon or Locamotion, but on staging. While not all the languages are required for certain projects, each community can opt in the projects at a later time.
 
-## What to Test
+## What to test
 
-### Pre-L10n Test
+### Pre-l10n test
 * Have your [glossary]((https://transvision.mozfr.org/) available as a reference, select mozilla.org as Repository, your language as your Target Locale
 * For terminology consistency, reference the product or site that the page is for, assuming the product or site is localized (e.g.: Firefox, Test Pilot)
 * Have the matching US page up as reference, though some strings may not be identical due to A/B testing
 * Have the project you just localized available for editing (Pontoon or Locamotion)
 
-### Linguistic Testing
+### Linguistic testing
 * Translation quality in context
 * Grammar correctness in context
 * Truncation: button text should remain inside the button
@@ -36,7 +36,7 @@ It’s highly advised you to ask other community members to conduct peer review 
 
 You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.org/projects/mozillaorg/), [Locamotion](https://mozilla.locamotion.org/projects/mozilla_lang/), or [GitHub](https://github.com/mozilla-l10n/www.mozilla.org/).
 
-### Functionality Testing
+### Functionality testing
 * Click the download link, you should be able to download the product in your language, if it is localized, such as Firefox
 * Font support and readability
 * Footer: verify that the translation of the link is coherent and the link is functional
@@ -44,12 +44,12 @@ You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.or
 * Error page: Deliberately type a broken link, such as https://www.mozilla.org/firefox/neu/, check whether [404 page](https://www-dev.allizom.org/404/) is localized
 * If your language is RTL, make sure that the page layout and text flow in the correct directions
 
-### Compatibility Testing:
+### Compatibility testing:
 * Test the page layout in other major browsers and on other platforms
 * Test the page layout on the leading locally developed browser if available
 * Test the page layout on mobile devices of major platforms
 
-## When Can I See the Localized Page on the Production Server?
+## When can I see the localized page on the production server?
 
 Updated translations are pushed to the production server almost daily.
 
@@ -57,7 +57,7 @@ When a brand new page is available for localization, it won’t be enabled in pr
 
 In some cases pages receive major updates that require a complete rewrite of the template: if this happens, the old template is kept online only for a short period of time and, when removed, it will cause the URL to redirect users to the English version.
 
-### Sync and Update Frequencies
+### Sync and update frequencies
 * Pontoon syncs every 20 minutes to the repository
 * Pootle is imported manually (at least daily); an automated solution and faster sync will be implemented soon
 * Web Dashboard and the Dev server update every 15 minutes
@@ -66,54 +66,57 @@ If you work on Pontoon, it is safe to say that it will take less than an hour to
 
 When a project has a firm deadline to meet, it will be communicated through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects.
 
-## Testing Dynamic Pages
-This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change overtime to reflect product design updates. Linguistic testing is the main focus. The instrutions below are detailed steps to get to the localized content so it can be reviewed in context.
+## Testing dynamic pages
+This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change over time to reflect product design updates. Linguistic testing is the main focus. The instrutions below are detailed steps to get to the localized content so it can be reviewed in context.
 
 ### [firefox/desktop/tips.lang](https://www.mozilla.org/firefox/desktop/tips/)   
 * Click on the **next** or **back** link to check out the tips on different features
 * Highlighted text is the same as in English
 * Text fits inside the box
 
-### [firefox/new/horizon.lang](https://www.mozilla.org/en-US/firefox/new/)
+### [firefox/new/horizon.lang](https://www.mozilla.org/firefox/new/)
 * Once page is loaded, click on the link called **Download Firefox for another platform**
 * For alternative message, change URL to [Scene2](https://www.mozilla.org/en-US/firefox/new/?scene=2)
 * To fully review the Firefox download page messages, tests must go through following scenarios:
-.. * Desktop: Windows, macOS, Linux
-.. * Mobile: Android and iOS
-.. * Updating from older version of Firefox to the latest vs. downloading for the first time
+ * Desktop: Windows, macOS, Linux
+ * Mobile: Android and iOS
+ * Updating from older version of Firefox to the latest vs. downloading for the first time
 
 ### [firefox/sendto.lang](https://www-dev.allizom.org/styleguide/docs/send-to-device/)
+The test can be done for all locales only on staging. Production is enabled only for these locales: 
 * Enter a mobile phone number, a new page will be generated, suggesting the next action to take
 * Enter a phone number in the wrong phone number format. This will prompt an error message
 
-### [firefox/sync.lang](https://www.mozilla.org/en-US/firefox/sync/) 
+### [firefox/sync.lang](https://www.mozilla.org/firefox/sync/) 
 
 ### firefox/tracking-protection-tour.lang
-* Start a new browser by clicking on the Firefox icon, select New Private Window on the menu list
+* Open Firefox and start a New Private Window
 * Once the window is launched, click on **See how it works** button
-* You are taken [step one](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=1)
-* Click the **Next** button, it takes you steps [two](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=2) and [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3)
+* You are taken to [step one](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=1)
+* Click the **Next** button, it takes you to steps [two](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=2) and [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3)
 * In step [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3), an extra text box appears 
 * Click on **Disable protection for this session** button to generate a new "step three" message  
 * Click on **Enable protection** button to toggle between "enable" and "disable" protection messages
+ * NOTE: In order to see the message of **Disable protection for this site**, the browser must be in _normal mode_
 * Click on **Got it!** button to get to the next page
 * Click on **Restart tour** button to go through the above steps  
+
 
 ### [mozorg/about/history.lang](https://www.mozilla.org/about/history/)
 * The slides should automatically scroll to the next in about 10 seconds or so 
 * If it doesn't or it stops, click the next or previous arrows to go to the next slide
-* Be sure to cycle to through until you see the first slide to ensure you have covered all the slides
+* Be sure to cycle through until you see the first slide again to ensure you have covered all the slides
 * Text fits inside the box
  
-### [mozorg/about/manifesto.lang](https://www.mozilla.org/en-US/about/manifesto/)
-You can check out the manifestos without going to the slide mode. However, only in the slide mode, all the localized content can be reviewed.
-* Click on the first manifesto
+### [mozorg/about/manifesto.lang](https://www.mozilla.org/about/manifesto/)
+You can check out the principles of the manifesto without going to the slide mode. However, only in the slide mode, all the localized content can be reviewed.
+* Click on the first principle
 * Click on the “next” and the “previous” arrows to move from one slide to the next
 * Check on text layout, alignment and wrapping. Box size should be adjustable to fit all the content
 
-### [mozorg/contribute/signup.lang](https://www.mozilla.org/contribute/signup/)
-There are different ways to access the signup dialog box above the footer area.  This is from the Contribute page.  
-* Click on any of the six icons or the links below each of them, you will be prompt to the Sign Up section
+### [mozorg/contribute/signup.lang](https://www.mozilla.org/)
+There are different ways to access the signup dialog box above the footer area. This is for signing up newsletters. 
+* Click on any of the six icons or the links below each of them, you will be prompted to the Sign Up section
 * Leave the name field empty, click on the **Sign Up Now** button. A text bubble will appear
 * Fill out the name field, leave the checkbox unchecked, click on the **Sign Up Now** button. A text bubble will appear
 * Fill out all the fields and check the box, click on the **Sign Up Now** button. A confirmation message appears on the page

--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -40,7 +40,7 @@ You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.or
 * Click the download link, you should be able to download the product in your language, if it is localized, such as Firefox
 * Font support and readability
 * Footer: verify that the translation of the link is coherent and the link is functional
-* Language list: Is your language listed as one of the options? Check https://www-dev.allizom.org/en-US/ to confirm
+* Language list: Is your language listed as one of the options? Check https://www-dev.allizom.org/ to confirm
 * Error page: Deliberately type a broken link, such as https://www.mozilla.org/firefox/neu/, check whether [404 page](https://www-dev.allizom.org/404/) is localized
 * If your language is RTL, make sure that the page layout and text flow in the correct directions
 
@@ -76,7 +76,7 @@ This section focuses on instructions for testing pages with dynamically generate
 
 ### [firefox/new/horizon.lang](https://www.mozilla.org/firefox/new/)
 * Once page is loaded, click on the link called **Download Firefox for another platform**
-* For alternative message, change URL to [Scene2](https://www.mozilla.org/en-US/firefox/new/?scene=2)
+* For alternative message, change URL to [Scene2](https://www.mozilla.org/firefox/new/?scene=2)
 * To fully review the Firefox download page messages, tests must go through following scenarios:
  * Desktop: Windows, macOS, Linux
  * Mobile: Android and iOS
@@ -92,9 +92,9 @@ The test can be done for all locales only on staging. For production testing, on
 ### firefox/tracking-protection-tour.lang
 * Open Firefox and start a New Private Window
 * Once the window is launched, click on **See how it works** button
-* You are taken to [step one](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=1)
-* Click the **Next** button, it takes you to steps [two](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=2) and [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3)
-* In step [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3), an extra text box appears 
+* You are taken to [step one](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=1)
+* Click the **Next** button, it takes you to steps [two](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=2) and [three](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=3)
+* In step [three](https://www.mozilla.org/firefox/51.0.1/tracking-protection/start/?step=3), an extra text box appears 
 * Click on **Disable protection for this session** button to generate a new "step three" message  
 * Click on **Enable protection** button to toggle between "enable" and "disable" protection messages
  * NOTE: In order to see the message of **Disable protection for this site**, the browser must be in _normal mode_

--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -83,7 +83,7 @@ This section focuses on instructions for testing pages with dynamically generate
  * Updating from older version of Firefox to the latest vs. downloading for the first time
 
 ### [firefox/sendto.lang](https://www-dev.allizom.org/styleguide/docs/send-to-device/)
-The test can be done for all locales only on staging. Production is enabled only for these locales: 
+The test can be done for all locales only on staging. For production testing, only these locales are enabled: de, en-GB, en-ZA, es-AR, es-CL, es-ES, es-MX, fr, id, pl, pt-BR, and ru.
 * Enter a mobile phone number, a new page will be generated, suggesting the next action to take
 * Enter a phone number in the wrong phone number format. This will prompt an error message
 
@@ -101,10 +101,9 @@ The test can be done for all locales only on staging. Production is enabled only
 * Click on **Got it!** button to get to the next page
 * Click on **Restart tour** button to go through the above steps  
 
-
 ### [mozorg/about/history.lang](https://www.mozilla.org/about/history/)
 * The slides should automatically scroll to the next in about 10 seconds or so 
-* If it doesn't or it stops, click the next or previous arrows to go to the next slide
+* If it does not or it stops, click the next or previous arrows to go to the next slide
 * Be sure to cycle through until you see the first slide again to ensure you have covered all the slides
 * Text fits inside the box
  
@@ -115,7 +114,7 @@ You can check out the principles of the manifesto without going to the slide mod
 * Check on text layout, alignment and wrapping. Box size should be adjustable to fit all the content
 
 ### [mozorg/contribute/signup.lang](https://www.mozilla.org/)
-There are different ways to access the signup dialog box above the footer area. This is for signing up newsletters. 
+There are different ways to access the signup dialog box above the footer area. This is for signing up to newsletters. 
 * Click on any of the six icons or the links below each of them, you will be prompted to the Sign Up section
 * Leave the name field empty, click on the **Sign Up Now** button. A text bubble will appear
 * Fill out the name field, leave the checkbox unchecked, click on the **Sign Up Now** button. A text bubble will appear

--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -65,3 +65,55 @@ In some cases pages receive major updates that require a complete rewrite of the
 If you work on Pontoon, it is safe to say that it will take less than an hour to see your changes reflected on the dashboard and the dev server.
 
 When a project has a firm deadline to meet, it will be communicated through the [dev-l10n-web mailing list](https://lists.mozilla.org/listinfo/dev-l10n-web). Be sure to sign up so you receive important community wide information on web related projects.
+
+## Testing Dynamic Pages
+This section focuses on instructions for testing pages with dynamically generated content. Each page or topic is different in terms of steps or flow. These instructions could change overtime to reflect product design updates. Linguistic testing is the main focus. The instrutions below are detailed steps to get to the localized content so it can be reviewed in context.
+
+### [firefox/desktop/tips.lang](https://www.mozilla.org/firefox/desktop/tips/)   
+* Click on the **next** or **back** link to check out the tips on different features
+* Highlighted text is the same as in English
+* Text fits inside the box
+
+### [firefox/new/horizon.lang](https://www.mozilla.org/en-US/firefox/new/)
+* Once page is loaded, click on the link called **Download Firefox for another platform**
+* For alternative message, change URL to [Scene2](https://www.mozilla.org/en-US/firefox/new/?scene=2)
+* To fully review the Firefox download page messages, tests must go through following scenarios:
+.. * Desktop: Windows, macOS, Linux
+.. * Mobile: Android and iOS
+.. * Updating from older version of Firefox to the latest vs. downloading for the first time
+
+### [firefox/sendto.lang](https://www-dev.allizom.org/styleguide/docs/send-to-device/)
+* Enter a mobile phone number, a new page will be generated, suggesting the next action to take
+* Enter a phone number in the wrong phone number format. This will prompt an error message
+
+### [firefox/sync.lang](https://www.mozilla.org/en-US/firefox/sync/) 
+
+### firefox/tracking-protection-tour.lang
+* Start a new browser by clicking on the Firefox icon, select New Private Window on the menu list
+* Once the window is launched, click on **See how it works** button
+* You are taken [step one](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=1)
+* Click the **Next** button, it takes you steps [two](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=2) and [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3)
+* In step [three](https://www.mozilla.org/en-US/firefox/51.0.1/tracking-protection/start/?step=3), an extra text box appears 
+* Click on **Disable protection for this session** button to generate a new "step three" message  
+* Click on **Enable protection** button to toggle between "enable" and "disable" protection messages
+* Click on **Got it!** button to get to the next page
+* Click on **Restart tour** button to go through the above steps  
+
+### [mozorg/about/history.lang](https://www.mozilla.org/about/history/)
+* The slides should automatically scroll to the next in about 10 seconds or so 
+* If it doesn't or it stops, click the next or previous arrows to go to the next slide
+* Be sure to cycle to through until you see the first slide to ensure you have covered all the slides
+* Text fits inside the box
+ 
+### [mozorg/about/manifesto.lang](https://www.mozilla.org/en-US/about/manifesto/)
+You can check out the manifestos without going to the slide mode. However, only in the slide mode, all the localized content can be reviewed.
+* Click on the first manifesto
+* Click on the “next” and the “previous” arrows to move from one slide to the next
+* Check on text layout, alignment and wrapping. Box size should be adjustable to fit all the content
+
+### [mozorg/contribute/signup.lang](https://www.mozilla.org/contribute/signup/)
+There are different ways to access the signup dialog box above the footer area.  This is from the Contribute page.  
+* Click on any of the six icons or the links below each of them, you will be prompt to the Sign Up section
+* Leave the name field empty, click on the **Sign Up Now** button. A text bubble will appear
+* Fill out the name field, leave the checkbox unchecked, click on the **Sign Up Now** button. A text bubble will appear
+* Fill out all the fields and check the box, click on the **Sign Up Now** button. A confirmation message appears on the page

--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -87,8 +87,6 @@ The test can be done for all locales only on staging. For production testing, on
 * Enter a mobile phone number, a new page will be generated, suggesting the next action to take
 * Enter a phone number in the wrong phone number format. This will prompt an error message
 
-### [firefox/sync.lang](https://www.mozilla.org/firefox/sync/) 
-
 ### firefox/tracking-protection-tour.lang
 * Open Firefox and start a New Private Window
 * Once the window is launched, click on **See how it works** button
@@ -112,10 +110,3 @@ You can check out the principles of the manifesto without going to the slide mod
 * Click on the first principle
 * Click on the “next” and the “previous” arrows to move from one slide to the next
 * Check on text layout, alignment and wrapping. Box size should be adjustable to fit all the content
-
-### [mozorg/contribute/signup.lang](https://www.mozilla.org/)
-There are different ways to access the signup dialog box above the footer area. This is for signing up to newsletters. 
-* Click on any of the six icons or the links below each of them, you will be prompted to the Sign Up section
-* Leave the name field empty, click on the **Sign Up Now** button. A text bubble will appear
-* Fill out the name field, leave the checkbox unchecked, click on the **Sign Up Now** button. A text bubble will appear
-* Fill out all the fields and check the box, click on the **Sign Up Now** button. A confirmation message appears on the page

--- a/products/mozilla_org/test_mozilla_org.md
+++ b/products/mozilla_org/test_mozilla_org.md
@@ -40,7 +40,7 @@ You can make linguistic changes directly in [Pontoon](https://pontoon.mozilla.or
 * Click the download link, you should be able to download the product in your language, if it is localized, such as Firefox
 * Font support and readability
 * Footer: verify that the translation of the link is coherent and the link is functional
-* Language list: Is your language listed as one of the options? Check https://www-dev.allizom.org/ to confirm
+* Language list: Is your language listed as one of the options? Check https://www-dev.allizom.org/en-US to confirm
 * Error page: Deliberately type a broken link, such as https://www.mozilla.org/firefox/neu/, check whether [404 page](https://www-dev.allizom.org/404/) is localized
 * If your language is RTL, make sure that the page layout and text flow in the correct directions
 


### PR DESCRIPTION
- Need review and verification of the steps
- Line #85, this page only exists on staging. Is there a production link?
- Line #89, can't seem to find a way to get to the Sync content. Are the messages for first time sync setup?
- Line #91, for this feature, I can’t get to this message as the feature is not offered in the current product: It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this site.”