### PR TITLE
add itemized and link formats to documentation style-guide

### DIFF
--- a/misc/documentation_styleguide.md
+++ b/misc/documentation_styleguide.md
@@ -13,7 +13,7 @@ These are some of the general rules to follow when writing and reviewing documen
 * Use lowercase after colons, only one space after a period.
 * Use proper quotes, like `“example”`, instead of straight double quotes.
 * Use typographical apostrophes `’` instead of straight single quotes `'` (code fragments are the only exception).
-* Use backticks `, bold, or italic to highlight text in a sentence, not quotes.
+* Use backticks `, **bold**, or *italic* to highlight text in a sentence, not quotes.
 * Try to use links instead of putting URLs directly in the text. For example, `visit [this page](http://example.com)` should be preferred to `visit http://example.com`.
 * Leave an empty line before and after code fragments, specify the language where possible. For example:
 
@@ -52,6 +52,24 @@ This is some text.
 
 This is some more text.
 ```
+
+## Bullet and numbered items
+
+First level is flushed all the way to the left. A sub level is offset by 4 spaces. The next sub level is offset by 8 spaces. You get the idea!
+
+```
+* The first level bullet point
+    * A second level bullet point
+        * A third level bullet point
+```
+
+## Links
+
+When cross reference a document, there are three kinds: within a document, within a project group, and outside a project group. The `[displayed text]` should be to the point and within a pair of square brackets. The displayed text must be followed by `(the link)` enclosed in a pair parenthesis. Follow the formats below to ensure link connection.
+
+* Reference within the same document: the link is proceeded with a # - [General rules]`(#General rules)`.
+* Reference within a project group: the link is proceeded with ../ - [Firefox Focus]`(../products/focus/testing_focus.md)`.
+* Reference outside mozilla-l10n group: the link is a full path - [OpenDesign github repository]`(https://github.com/mozilla/OpenDesign/tree/master/2017)`.
 
 ## Tools
 

--- a/misc/documentation_styleguide.md
+++ b/misc/documentation_styleguide.md
@@ -14,6 +14,7 @@ These are some of the general rules to follow when writing and reviewing documen
 * Use proper quotes, like `“example”`, instead of straight double quotes.
 * Use typographical apostrophes `’` instead of straight single quotes `'` (code fragments are the only exception).
 * Use backticks `, **bold**, or *italic* to highlight text in a sentence, not quotes.
+* Use * instead of _ for bold and italic.
 * Try to use links instead of putting URLs directly in the text. For example, `visit [this page](http://example.com)` should be preferred to `visit http://example.com`.
 * Leave an empty line before and after code fragments, specify the language where possible. For example:
 
@@ -55,7 +56,7 @@ This is some more text.
 
 ## Bullet and numbered items
 
-First level is flushed all the way to the left. A sub level is offset by 4 spaces. The next sub level is offset by 8 spaces. You get the idea!
+The first level has no indentation, and it's completely aligned to the left. Sub levels should be indented using 4 spaces. Use `*` instead of `-` to create items. Example:
 
 ```
 * The first level bullet point
@@ -65,11 +66,24 @@ First level is flushed all the way to the left. A sub level is offset by 4 space
 
 ## Links
 
-When cross reference a document, there are three kinds: within a document, within a project group, and outside a project group. The `[displayed text]` should be to the point and within a pair of square brackets. The displayed text must be followed by `(the link)` enclosed in a pair parenthesis. Follow the formats below to ensure link connection.
+There are three kind of links when cross referencing a document: within a document, within a project group, and outside a project group. The `[displayed text]` should be to the point and within a pair of square brackets. The displayed text must be followed by `(the link)` enclosed in a pair of parenthesis. Follow these formats for each case:
 
-* Reference within the same document: the link is proceeded with a # - [General rules]`(#General rules)`.
-* Reference within a project group: the link is proceeded with ../ - [Firefox Focus]`(../products/focus/testing_focus.md)`.
-* Reference outside mozilla-l10n group: the link is a full path - [OpenDesign github repository]`(https://github.com/mozilla/OpenDesign/tree/master/2017)`.
+* Reference within the same document: link directly to the anchor, e.g. `[General rules](#general-rules)`. Note that GitHub automatically creates anchors for titles: if the title is *Title Example*, the anchor will be lowercase, with spaces replaced by dashes, i.e. `#title-example`.
+* Reference within a project group: use relative links, instead of absolute links (starting with `/`) or full GitHub URLs. For example, to link to a document in the parent folder, use `[other document](../other.md)`.
+* Reference outside the current repository: use the full GitHub URL, e.g. `[OpenDesign GitHub repository](https://github.com/mozilla/OpenDesign/tree/master/2017)`.
+
+## Images
+
+When adding images to a repository, make sure that the size is not too big for the content displayed on GitHub. In case of PNG files, make also sure to optimize files through online services like [TinyPNG](https://tinypng.com/).
+
+* Create a folder that maps to your folder. If there are too many images, create a subfolder for a particular document.
+* Naming convention: if only a couple of images are needed, make the file name easily identifiable, e.g.: product_feature_type.png.
+* File name: No spaces, no uppercase, use underscore if there are more than two words.
+* File size: keep it under 800px. If necessary, create two versions: a small one and a bigger one when clicked.
+* Image insertion and format:
+    * `![Encoding bug](/assets/images/l10n_testing/encoding_bug.png)`: This is a standalone image, within the testing topic.
+    * `![Pontoon login](/assets/images/pontoon/users/translation_locales.png)`: this is one of the many images within the subfolder of **Pontoon Users** topics.
+* When images with personal information are clearly on display, blur it out.    
 
 ## Tools
 

--- a/misc/documentation_styleguide.md
+++ b/misc/documentation_styleguide.md
@@ -14,7 +14,7 @@ These are some of the general rules to follow when writing and reviewing documen
 * Use proper quotes, like `“example”`, instead of straight double quotes.
 * Use typographical apostrophes `’` instead of straight single quotes `'` (code fragments are the only exception).
 * Use backticks `, **bold**, or *italic* to highlight text in a sentence, not quotes.
-* Use * instead of _ for bold and italic.
+* Use `*` instead of `_` for bold and italic.
 * Try to use links instead of putting URLs directly in the text. For example, `visit [this page](http://example.com)` should be preferred to `visit http://example.com`.
 * Leave an empty line before and after code fragments, specify the language where possible. For example:
 
@@ -76,14 +76,12 @@ There are three kind of links when cross referencing a document: within a docume
 
 When adding images to a repository, make sure that the size is not too big for the content displayed on GitHub. In case of PNG files, make also sure to optimize files through online services like [TinyPNG](https://tinypng.com/).
 
-* Create a folder that maps to your folder. If there are too many images, create a subfolder for a particular document.
+* Create a folder that maps to the main folder in which your documented is stored.
 * Naming convention: if only a couple of images are needed, make the file name easily identifiable, e.g.: product_feature_type.png.
-* File name: No spaces, no uppercase, use underscore if there are more than two words.
-* File size: keep it under 800px. If necessary, create two versions: a small one and a bigger one when clicked.
-* Image insertion and format:
-    * `![Encoding bug](/assets/images/l10n_testing/encoding_bug.png)`: This is a standalone image, within the testing topic.
-    * `![Pontoon login](/assets/images/pontoon/users/translation_locales.png)`: this is one of the many images within the subfolder of **Pontoon Users** topics.
-* When images with personal information are clearly on display, blur it out.    
+* File name must not spaces and uppercase, and must use underscore to separate words as needed.
+* Image size: keep it under 800px. If necessary, create two versions: a small one and a bigger one to open when clicked.
+* Image format: `![Encoding bug](/assets/images/l10n_testing/encoding_bug.png)`
+* When images contain personal information, such as email addresses, try to blur it out.   
 
 ## Tools
 

--- a/misc/documentation_styleguide.md
+++ b/misc/documentation_styleguide.md
@@ -81,7 +81,7 @@ When adding images to a repository, make sure that the size is not too big for t
 * File name must not contain spaces and uppercase, and must use underscore to separate words as needed.
 * Image size: keep it under 800px. If necessary, create two versions: a small one and a bigger one to open when clicked.
 * Image format: `![Encoding bug](/assets/images/l10n_testing/encoding_bug.png)`.
-* When images contain personal information, such as email addresses, try to blur it out.   
+* When images contain personal information, such as email addresses, try to blur it out.
 
 ## Tools
 

--- a/misc/documentation_styleguide.md
+++ b/misc/documentation_styleguide.md
@@ -78,9 +78,9 @@ When adding images to a repository, make sure that the size is not too big for t
 
 * Create a folder that maps to the main folder in which your documented is stored.
 * Naming convention: if only a couple of images are needed, make the file name easily identifiable, e.g.: product_feature_type.png.
-* File name must not spaces and uppercase, and must use underscore to separate words as needed.
+* File name must not contain spaces and uppercase, and must use underscore to separate words as needed.
 * Image size: keep it under 800px. If necessary, create two versions: a small one and a bigger one to open when clicked.
-* Image format: `![Encoding bug](/assets/images/l10n_testing/encoding_bug.png)`
+* Image format: `![Encoding bug](/assets/images/l10n_testing/encoding_bug.png)`.
 * When images contain personal information, such as email addresses, try to blur it out.   
 
 ## Tools


### PR DESCRIPTION
Not sure if I captured all on the link type

