### PR TITLE
Updated missing section about exclude-multi-locale

### DIFF
--- a/products/firefox_android/adding_multilocales.md
+++ b/products/firefox_android/adding_multilocales.md
@@ -46,6 +46,7 @@ The second file to modify is `mobile/android/locales/l10n.toml`. This is the beg
 basepath = "../../.."
 
 locales = [
+    "ab-CD",
     "an",
     "ar",
     "as",
@@ -54,9 +55,9 @@ locales = [
 ...
 ```
 
-Identify the `locales` section, and make sure the locale is already listed under the `locales` section (it should be already).
+Identify the `locales` section, and make sure the locale is already listed under the `locales` section (it should be already). In the example above, the locale is represented by `ab-CD`.
 
-Then locate the `exclude-multi-locale` section, and remove it from there.
+Then locate the `exclude-multi-locale` section, and remove the locale from there.
 
 After you’ve finished editing the files, check the status of the repository, and the diff.
 
@@ -82,7 +83,7 @@ $ hg diff
  --- a/mobile/android/locales/l10n.toml
  +++ b/mobile/android/locales/l10n.toml
  @@ -9,8 +9,9 @@ locales = [
- +    "ab-CD",
+      "ab-CD",
       "ar",
       "be",
       "ca",

--- a/products/firefox_android/adding_multilocales.md
+++ b/products/firefox_android/adding_multilocales.md
@@ -55,9 +55,9 @@ locales = [
 ...
 ```
 
-Identify the `locales` section, and make sure the locale is already listed under the `locales` section (it should be already). In the example above, the locale is represented by `ab-CD`.
+Identify the `locales` section, and make sure the locale is already listed under the `locales` section (it should have been added when enabling single locale builds). In the example above, the locale is represented by `ab-CD`.
 
-Then locate the `exclude-multi-locale` section, and remove the locale from there.
+Then locate the `exclude-multi-locale` section, and remove the locale from this list.
 
 After you’ve finished editing the files, check the status of the repository, and the diff.
 

--- a/products/firefox_android/adding_multilocales.md
+++ b/products/firefox_android/adding_multilocales.md
@@ -18,7 +18,7 @@ Release Note Request (optional, but appreciated)
 [Links (documentation, blog post, etc)]:
 ```
 
-## Creating a patch build configuration
+## Creating a patch for build configuration
 
 First of all make sure that your environment is [correctly set up](../../tools/mercurial/setting_mercurial_environment.md), and update your local mozilla-unified clone:
 

--- a/products/firefox_android/adding_multilocales.md
+++ b/products/firefox_android/adding_multilocales.md
@@ -18,7 +18,7 @@ Release Note Request (optional, but appreciated)
 [Links (documentation, blog post, etc)]:
 ```
 
-## Creating a patch for maemo-locales
+## Creating a patch build configuration
 
 First of all make sure that your environment is [correctly set up](../../tools/mercurial/setting_mercurial_environment.md), and update your local mozilla-unified clone:
 
@@ -28,7 +28,7 @@ $ hg pull -r default -u
 $ hg update central
 ```
 
-The file to modify is in `mobile/android/locales/maemo-locales`, open it with your text editor of choice.
+The first file to modify is in `mobile/android/locales/maemo-locales`, open it with your text editor of choice.
 
 ```BASH
 $ atom mobile/android/locales/maemo-locales
@@ -36,7 +36,29 @@ $ atom mobile/android/locales/maemo-locales
 
 And add the new locale to the list. With Atom and the Sort Lines package installed, you can press `F5` to make sure that the list is in **alphabetical order**. Let’s say for example that you need to add `ab-CD` to the list of supported locales.
 
-After you’ve finished editing the file, check the status of the repository, and the diff.
+The second file to modify is `mobile/android/locales/l10n.toml`. This is the beginning of the file:
+
+```
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+basepath = "../../.."
+
+locales = [
+    "an",
+    "ar",
+    "as",
+    "ast",
+    "az",
+...
+```
+
+Identify the `locales` section, and make sure the locale is already listed under the `locales` section (it should be already).
+
+Then locate the `exclude-multi-locale` section, and remove it from there.
+
+After you’ve finished editing the files, check the status of the repository, and the diff.
 
 ```BASH
 $ hg status
@@ -55,9 +77,26 @@ $ hg diff
  de
  es-AR
  es-ES
+
+ diff --git a/mobile/android/locales/l10n.toml b/mobile/android/locales/l10n.toml
+ --- a/mobile/android/locales/l10n.toml
+ +++ b/mobile/android/locales/l10n.toml
+ @@ -9,8 +9,9 @@ locales = [
+ +    "ab-CD",
+      "ar",
+      "be",
+      "ca",
+      "cs",
+      "da",
+      "es-AR",
+@@ -9,8 +9,9 @@ exclude-multi-locale = [
+  -    "ab-CD",
+       "ia",
+       "oc",
+...
 ```
 
-`M` in `hg status` indicates that the file has been modified, `+` in `hg diff` that the line has been added. Follow the instructions available in [this document](../../tools/mercurial/creating_mercurial_patch.md) to create a patch, submit it for review, and land it.
+`M` in `hg status` indicates that the file has been modified, `+` in `hg diff` that the line has been added, and `-` means it was removed. Follow the instructions available in [this document](../../tools/mercurial/creating_mercurial_patch.md) to create a patch, submit it for review, and land it.
 
 **IMPORTANT:** an error in a single locale is going to break the multi-locales build for all locales, English included.
 

--- a/products/firefox_android/adding_singlelocale.md
+++ b/products/firefox_android/adding_singlelocale.md
@@ -60,6 +60,8 @@ locales = [
 
 Identify the `locales` section, and add the new locale code between double quotes, followed by a comma. As before, you can use Atom to make sure the list is in alphabetical order (make sure to select only the lines with actual locale codes before pressing `F5`).
 
+Once this is done, identify the `exclude-multi-locale` section. Since this locale is not shipping on multi-locale builds yet, you should add it there too, in the same way you just did above.
+
 After you’ve finished editing the files, check the status of the repository, and the diff.
 
 ```BASH
@@ -91,6 +93,11 @@ $ hg diff
       "cs",
       "da",
       "es-AR",
+@@ -9,8 +9,9 @@ exclude-multi-locale = [
+  +    "ab-CD",
+       "ia",
+       "oc",
+...
 ```
 
 `M` in `hg status` indicates that the file has been modified, `+` in `hg diff` that the line has been added. Follow the instructions available in [this document](../../tools/mercurial/creating_mercurial_patch.md) to create a patch, submit it for review, and land it.

--- a/products/firefox_android/adding_singlelocale.md
+++ b/products/firefox_android/adding_singlelocale.md
@@ -22,7 +22,7 @@ After the first content lands in l10n-central, it’s a good idea to perform som
 
 Check the [Set up searchplugins](../searchplugins/setup_searchplugins.md) document for detailed instructions on how to set up searchplugins for new locales.
 
-## Creating a patch for all-locales
+## Creating a patch for build configuration
 
 First of all make sure that your environment is [correctly set up](../../tools/mercurial/setting_mercurial_environment.md), and update your local mozilla-unified clone:
 

--- a/products/firefox_android/adding_singlelocale.md
+++ b/products/firefox_android/adding_singlelocale.md
@@ -60,7 +60,7 @@ locales = [
 
 Identify the `locales` section, and add the new locale code between double quotes, followed by a comma. As before, you can use Atom to make sure the list is in alphabetical order (make sure to select only the lines with actual locale codes before pressing `F5`).
 
-Once this is done, identify the `exclude-multi-locale` section. Since this locale is not shipping on multi-locale builds yet, you should add it there too, in the same way you just did above.
+Once this is done, identify the `exclude-multi-locale` section. Since this locale is not shipping on multi-locale builds yet, you should add it there too.
 
 After you’ve finished editing the files, check the status of the repository, and the diff.
 


### PR DESCRIPTION
This tackles what was missing for this doc about "exclude-multi-locale" section of toml file, as per #121 