### PR TITLE
Bug 1499512: Support Google Cloud Translation API

### DIFF
--- a/tools/pontoon/adding_new_locale.md
+++ b/tools/pontoon/adding_new_locale.md
@@ -18,6 +18,10 @@ You will need to complete the following fields in the next page.
 
 It’s the locale code, in this case `am`.
 
+### Google Translate code
+
+Google Translate maintains a list of supported locales in its own format. Choose one that matches the locale from [a list of supported locales](https://translate.google.com/intl/en/about/languages/) or leave it blank to disable support for Google Translate for this locale.
+
 ### MS translator code
 
 Microsoft Translator maintains a list of supported locales in its own format. Choose one that matches the locale from [a list of supported locales](https://msdn.microsoft.com/en-us/library/hh456380.aspx) or leave it blank to disable support for Microsoft Translator for this locale.


### PR DESCRIPTION
We'll be switching the MT engine on pontoon.mozilla.org from Microsoft Translator to Google Translate after [bug 1499512](https://bugzilla.mozilla.org/show_bug.cgi?id=1499512) lands.

Google Translate maintains a list of supported locales in its own format, so we need to assign locale codes for it when adding new locales to Pontoon.

The existing Pontoon locales have already been taken care of:
https://github.com/mozilla/pontoon/pull/1104/files#diff-bf043eb7b8f43008cf9f4473a3094417