### PR TITLE
s/dash/hash

### DIFF
--- a/src/misc/documentation_styleguide.md
+++ b/src/misc/documentation_styleguide.md
@@ -30,7 +30,7 @@ This is some other text.
 
 ## Titles
 
-* Use the dash syntax, leave one space after the dash, e.g. `# This is a title`.
+* Use the hash syntax, leave one space after the hash, e.g. `# This is a title`.
 * Use sentence case, avoid title case.
 * Documents should always start with a 1st level title. There should be **only one** 1st level title across the document.
 * Leave an empty line before and after each title. The only exception is the 1st level title at the beginning of the page.


### PR DESCRIPTION
I've heard `#` referred to as a "pound symbol", "number symbol", **"hash(tag)",** "octothorpe", but never as a "dash".

Many markdown style guides refer to it as a "hash" (eg. https://daringfireball.net/projects/markdown/basics). This commit updates our style guide to follow suit.