### PR TITLE
Add revsetalias for hg wip doc (fixes #256)

### DIFF
--- a/src/tools/mercurial/setting_mercurial_environment.md
+++ b/src/tools/mercurial/setting_mercurial_environment.md
@@ -101,6 +101,11 @@ Some aliases are also useful to work with bookmarks:
 shortlog = log --template "{node|short} | {date|isodatesec} | {author|user}: {desc|strip|firstline}\n"
 wip = log --graph --rev=wip --template=wip
 
+[revsetalias]
+wip = (parents(not public()) or not public() or . or (head() and branch(default))) and (not obsolete() or orphan()^) and not closed()
+# If firefoxtree is enabled
+# wip = (parents(not public()) or not public() or . or (head() and branch(default))) and (not obsolete() or orphan()^) and not closed() and not (fxheads() - date(-90))
+
 [templates]
 wip = '{label("log.branch", branches)} {label("changeset.{phase}", rev)}{label("changeset.{phase}", ":")}{label("changeset.{phase}", short(node))} {label("grep.user", author|user)}{label("log.tag", if(tags," {tags}"))}{label("log.tag", if(fxheads," {fxheads}"))} {label("log.bookmark", if(bookmarks," {bookmarks}"))}\n{label(ifcontains(rev, revset("."), "desc.here"),desc|firstline)}'
 ```


### PR DESCRIPTION
The revset is from the following lines:
https://searchfox.org/version-control-tools/rev/71e2f449e817589e7a41bbe2a69cd648e4510ff0/hgext/configwizard/__init__.py#1052-1066

the definition is conditional on the 2 things:
  * for mercurial 4.5.* or older, the revset is slightly different (`orphan` -> `unstable`), but I dropped it because it's from 4 years ago
  * if `firefoxtree` extension is enabled, the definition excludes heads from older branches, I've added it as comment
