### PR TITLE
Add some notes about landing strings early in feature development.

### DIFF
--- a/src/localization/dev_best_practices.md
+++ b/src/localization/dev_best_practices.md
@@ -57,6 +57,7 @@ Don’t forget to add a localization note when:
 * English could be ambiguous. For example: `bookmark` can be a noun or a verb. Using meaningful IDs can also help in these cases.
 * Strings are used in a specific context. For example accessibility (a11y) strings: in this case space is less important than clarity, since these strings are not displayed in the UI but used by tools like screen readers.
 * The string contains an adjective, but the noun it refers to is not part of the string. Most languages need to decline adjectives based on number and gender.
+* The UI that the string is used for is not testable yet. In this case, a comment supplying links to screenshots or public Figma specifications can reduce ambiguity and unblock the localization of the strings. Once the UI is testable, these links can be removed from the comments.
 
 There is an established format for localization comments: it’s important to follow the format as closely as possible, since there are a number of automated tools that parse these comments for easier access and use by localizers.
 

--- a/src/products/firefox_desktop/firefox_l10n_faqs.md
+++ b/src/products/firefox_desktop/firefox_l10n_faqs.md
@@ -127,7 +127,7 @@ Local builds:
 
 ### Can I land strings early, before my feature is fully built-out?
 
-Except for special cases, strings should be landed at the same time as the associated UI changes. Otherwise, this makes it difficult for our localizers to know how the strings are being used, which can make it harder to supply an accurate translation that fully fits the context. 
+Except for special cases, strings should be landed at the same time as the associated UI changes. Otherwise, this makes it difficult for our localizers to know how the strings are being used, which can make it harder to supply an accurate translation that fully fits the context.
 
 Please consult with a [localization PM](#who-can-i-contact-if-i-have-more-questions) if you have a need to land strings early. Note that landing strings early would also involve additional considerations such as:
 

--- a/src/products/firefox_desktop/firefox_l10n_faqs.md
+++ b/src/products/firefox_desktop/firefox_l10n_faqs.md
@@ -127,7 +127,9 @@ Local builds:
 
 ### Can I land strings early, before my feature is fully built-out?
 
-This makes it difficult for our localizers to know how the strings are being used, which can make it harder to supply a translation that fully fits the context. If you plan on going this route, it is only advisable with the following conditions:
+Except for special cases, strings should be landed at the same time as the associated UI changes. Otherwise, this makes it difficult for our localizers to know how the strings are being used, which can make it harder to supply an accurate translation that fully fits the context. 
+
+Please consult with a [localization PM](#who-can-i-contact-if-i-have-more-questions) if you have a need to land strings early. Note that landing strings early would also involve additional considerations such as:
 
 1. The strings do not change after they merge to the Beta repository
 2. The strings include comments that link to public-facing screenshots or Figma specifications to help our localizers understand how the strings are being used

--- a/src/products/firefox_desktop/firefox_l10n_faqs.md
+++ b/src/products/firefox_desktop/firefox_l10n_faqs.md
@@ -125,6 +125,15 @@ Local builds:
 * You can [build directly in a different locale](https://firefox-source-docs.mozilla.org/build/buildsystem/locales.html#instructions-for-single-locale-repacks-for-developers) (no support for artifact builds).
 * It’s possible to add specific l10n repacks to a [Try Server](https://wiki.mozilla.org/ReleaseEngineering/TryServer#Scheduling_jobs_with_Treeherder) push. For example, to add French: select *Add new Jobs*, then select the `fr` locale in `L10n-Rpk`. Once the job is completed, builds will be available as artifacts under `L10n (BsX)`, where `X` changes depending on the locale.
 
+### Can I land strings early, before my feature is fully built-out?
+
+This makes it difficult for our localizers to know how the strings are being used, which can make it harder to supply a translation that fully fits the context. If you plan on going this route, it is only advisable with the following conditions:
+
+1. The strings do not change after they merge to the Beta repository
+2. The strings include comments that link to public-facing screenshots or Figma specifications to help our localizers understand how the strings are being used
+
+Once the feature is built-out and testable, the links in the comments can be removed.
+
 ## Translation completion and community
 
 ### Is my feature going to be localized in language X before launch?

--- a/src/products/firefox_desktop/firefox_l10n_faqs.md
+++ b/src/products/firefox_desktop/firefox_l10n_faqs.md
@@ -131,8 +131,9 @@ Except for special cases, strings should be landed at the same time as the assoc
 
 Please consult with a [localization PM](#who-can-i-contact-if-i-have-more-questions) if you have a need to land strings early. Note that landing strings early would also involve additional considerations such as:
 
-1. The strings do not change after they merge to the Beta repository
-2. The strings include comments that link to public-facing screenshots or Figma specifications to help our localizers understand how the strings are being used
+1. The strings must still be [good quality strings](../../localization/dev_best_practices.md#land-good-quality-strings), not temporary or placeholders
+2. The strings do not change after they merge to the Beta repository
+3. The strings include comments that link to public-facing screenshots or Figma specifications to help our localizers understand how the strings are being used
 
 Once the feature is built-out and testable, the links in the comments can be removed.
 


### PR DESCRIPTION
This is based on some conversations I've had with @bcolsson and @flodolo recently about the New Tab team's intent to ship more quickly, and thought it'd be worth adding to the documentation.